### PR TITLE
fix: only change output selection on tests

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -7,7 +7,7 @@ import 'hardhat-gas-reporter';
 import 'hardhat-contract-sizer';
 import 'hardhat-deploy';
 import 'solidity-coverage';
-import { HardhatUserConfig, NetworksUserConfig } from 'hardhat/types';
+import { HardhatUserConfig, MultiSolcUserConfig, NetworksUserConfig } from 'hardhat/types';
 import { getNodeUrl, accounts } from './utils/network';
 import { utils } from 'ethers';
 
@@ -71,11 +71,6 @@ const config: HardhatUserConfig = {
             enabled: true,
             runs: 200,
           },
-          outputSelection: {
-            '*': {
-              '*': ['storageLayout'],
-            },
-          },
         },
       },
       {
@@ -112,5 +107,20 @@ const config: HardhatUserConfig = {
     apiKey: process.env.ETHERSCAN_API_KEY,
   },
 };
+
+if (process.env.TEST) {
+  const solidity = config.solidity as MultiSolcUserConfig;
+  solidity.compilers.forEach((_, i) => {
+    solidity.compilers[i].settings! = {
+      ...solidity.compilers[i].settings!,
+      outputSelection: {
+        '*': {
+          '*': ['storageLayout'],
+        },
+      },
+    };
+  });
+  config.solidity = solidity;
+}
 
 export default config;


### PR DESCRIPTION
We stop intervention on `storage` when is not a test.