### PR TITLE
refactor: group everything in register swap

### DIFF
--- a/test/utils/bn.ts
+++ b/test/utils/bn.ts
@@ -1,4 +1,4 @@
-import { BigNumber } from 'ethers';
+import { BigNumber, BigNumberish } from 'ethers';
 import { expect } from 'chai';
 
 const expectToEqualWithThreshold = ({
@@ -27,7 +27,7 @@ const expectArraysToBeEqual = (arr1: BigNumber[] | number[] | string[], arr2: Bi
   });
 };
 
-const toBN = (value: string | number | BigNumber): BigNumber => {
+const toBN = (value: BigNumberish): BigNumber => {
   return BigNumber.isBigNumber(value) ? value : BigNumber.from(value);
 };
 


### PR DESCRIPTION
Even after https://github.com/Mean-Finance/dca-v1.1/pull/20, I still felt pretty uncomfortable with the code. When registering a swap, we were making changes in `_addRatePerUnit`, in `_registerSwap` and also inside `swap`.

But IMHO, the biggest pain point were the tests. We had to to set up almost the same test a lot, and make sure that everyone was calling everyone correctly.

So I moved all registering logic to `_registerSwap`, so we can test it there. Also, now we only need to test that `swap` calls `_registerSwap` and we can forget about it