### PR TITLE
feat: add swap input helper

### DIFF
--- a/js-lib/swap-utils.ts
+++ b/js-lib/swap-utils.ts
@@ -1,0 +1,57 @@
+export type TokenAddress = string;
+
+export type Pair = {
+  tokenA: TokenAddress;
+  tokenB: TokenAddress;
+};
+
+export type PairIndex = {
+  indexTokenA: number;
+  indexTokenB: number;
+};
+
+export function buildSwapInput(pairs: Pair[]): { tokens: TokenAddress[]; indexes: PairIndex[] } {
+  const tokens: TokenAddress[] = getUniqueTokens(pairs);
+  const indexes = getIndexes(pairs, tokens);
+  assertValid(indexes);
+  return { tokens, indexes };
+}
+
+function assertValid(indexes: PairIndex[]) {
+  for (const { indexTokenA, indexTokenB } of indexes) {
+    if (indexTokenA === indexTokenB) {
+      throw Error('Found duplicates in same pair');
+    }
+  }
+
+  for (let i = 1; i < indexes.length; i++) {
+    if (indexes[i - 1].indexTokenA === indexes[i].indexTokenA && indexes[i - 1].indexTokenB === indexes[i].indexTokenB) {
+      throw Error('Found duplicates');
+    }
+  }
+}
+
+/**
+ * Given a list of pairs and a list of sorted tokens, maps each pair into the index of each token
+ * (inside the list of tokens). The list of indexes will also be sorted, first by tokenA and then by tokenB
+ */
+function getIndexes(pairs: Pair[], tokens: TokenAddress[]): PairIndex[] {
+  return pairs
+    .map(({ tokenA, tokenB }) => ({ indexTokenA: tokens.indexOf(tokenA), indexTokenB: tokens.indexOf(tokenB) }))
+    .map(({ indexTokenA, indexTokenB }) => ({
+      indexTokenA: Math.min(indexTokenA, indexTokenB),
+      indexTokenB: Math.max(indexTokenA, indexTokenB),
+    }))
+    .sort((a, b) => a.indexTokenA - b.indexTokenA || a.indexTokenB - b.indexTokenB);
+}
+
+/** Given a list of pairs, returns a sorted list of the tokens involved */
+function getUniqueTokens(pairs: Pair[]): TokenAddress[] {
+  const tokenSet: Set<TokenAddress> = new Set();
+  for (const { tokenA, tokenB } of pairs) {
+    tokenSet.add(tokenA);
+    tokenSet.add(tokenB);
+  }
+
+  return [...tokenSet].sort();
+}

--- a/test/unit/js-lib/swap-utils.spec.ts
+++ b/test/unit/js-lib/swap-utils.spec.ts
@@ -1,0 +1,71 @@
+import { expect } from 'chai';
+import { buildSwapInput } from '../../../js-lib/swap-utils';
+import { when, then } from '../../utils/bdd';
+
+describe('Swap Utils', () => {
+  describe('buildSwapInput', () => {
+    const TOKEN_A = 'tokenA';
+    const TOKEN_B = 'tokenB';
+    when('no pairs are given', () => {
+      then('the result is empty', () => {
+        const { tokens, indexes } = buildSwapInput([]);
+        expect(tokens).to.be.empty;
+        expect(indexes).to.be.empty;
+      });
+    });
+
+    when('one pair has the same token', () => {
+      then('an error is thrown', () => {
+        const pair = { tokenA: 'token', tokenB: 'token' };
+        expect(() => buildSwapInput([pair])).to.throw('Found duplicates in same pair');
+      });
+    });
+
+    when('there are duplicated pairs', () => {
+      then('an error is thrown', () => {
+        const pair = { tokenA: TOKEN_A, tokenB: TOKEN_B };
+        expect(() => buildSwapInput([pair, pair])).to.throw('Found duplicates');
+      });
+    });
+
+    when('there are duplicated pairs', () => {
+      then('an error is thrown', () => {
+        const pair1 = { tokenA: TOKEN_A, tokenB: TOKEN_B };
+        const pair2 = { tokenA: TOKEN_B, tokenB: TOKEN_A };
+        expect(() => buildSwapInput([pair1, pair2])).to.throw('Found duplicates');
+      });
+    });
+
+    when('one pair is provided', () => {
+      then('the result is returned correctly', () => {
+        const pair = { tokenA: TOKEN_B, tokenB: TOKEN_A };
+        const { tokens, indexes } = buildSwapInput([pair]);
+        expect(tokens).to.eql([TOKEN_A, TOKEN_B]);
+        expect(indexes).to.eql([{ indexTokenA: 0, indexTokenB: 1 }]);
+      });
+    });
+
+    when('multiple pairs are provided', () => {
+      const TOKEN_C = 'tokenC';
+      const TOKEN_D = 'tokenD';
+
+      then('the result is returned correctly', () => {
+        const { tokens, indexes } = buildSwapInput([
+          { tokenA: TOKEN_C, tokenB: TOKEN_A },
+          { tokenA: TOKEN_B, tokenB: TOKEN_A },
+          { tokenA: TOKEN_D, tokenB: TOKEN_B },
+          { tokenA: TOKEN_D, tokenB: TOKEN_C },
+          { tokenA: TOKEN_B, tokenB: TOKEN_C },
+        ]);
+        expect(tokens).to.eql([TOKEN_A, TOKEN_B, TOKEN_C, TOKEN_D]);
+        expect(indexes).to.eql([
+          { indexTokenA: 0, indexTokenB: 1 },
+          { indexTokenA: 0, indexTokenB: 2 },
+          { indexTokenA: 1, indexTokenB: 2 },
+          { indexTokenA: 1, indexTokenB: 3 },
+          { indexTokenA: 2, indexTokenB: 3 },
+        ]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This is one more small change before the new `getNextSwapInfo`. We decided that both `getNextSwapInfo` and `swap` will look like this: `function(tokens: Token[], indexes: { indexTokenA: number, indexTokenB: number }[])`

Now, this can be a little annoying to build, so we are adding a helper that takes a list of pairs, and build the correct input.