### PR TITLE
feat: add public getNextSwapInfo

### DIFF
--- a/contracts/DCAHub/DCAHubPositionHandler.sol
+++ b/contracts/DCAHub/DCAHubPositionHandler.sol
@@ -53,13 +53,15 @@ abstract contract DCAHubPositionHandler is ReentrancyGuard, DCAHubParameters, ID
     if (_owner == address(0)) revert CommonErrors.ZeroAddress();
     if (_tokenAddress != address(tokenA) && _tokenAddress != address(tokenB)) revert InvalidToken();
     if (_amountOfSwaps == 0) revert ZeroSwaps();
-    if (!_activeSwapIntervals.contains(_swapInterval) && !globalParameters.isSwapIntervalAllowed(_swapInterval)) revert InvalidInterval();
+    if (
+      !_activeSwapIntervals[address(tokenA)][address(tokenB)].contains(_swapInterval) && !globalParameters.isSwapIntervalAllowed(_swapInterval)
+    ) revert InvalidInterval();
     uint256 _amount = _rate * _amountOfSwaps;
     IERC20Metadata(_tokenAddress).safeTransferFrom(msg.sender, address(this), _amount);
     _balances[_tokenAddress] += _amount;
     _idCounter += 1;
     _safeMint(_owner, _idCounter);
-    _activeSwapIntervals.add(_swapInterval);
+    _activeSwapIntervals[address(tokenA)][address(tokenB)].add(_swapInterval);
     (uint32 _startingSwap, uint32 _finalSwap) = _addPosition(
       _idCounter,
       _tokenAddress,

--- a/contracts/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/DCAHub/DCAHubSwapHandler.sol
@@ -33,9 +33,8 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubParameters, IDCAHu
     swapAmountDelta[_tokenB][_tokenA][_swapInterval][_swapToRegister + 1] += swapAmountDelta[_tokenB][_tokenA][_swapInterval][_swapToRegister];
     delete swapAmountDelta[_tokenA][_tokenB][_swapInterval][_swapToRegister];
     delete swapAmountDelta[_tokenB][_tokenA][_swapInterval][_swapToRegister];
-    // TODO: Investigate if sorting the tokens and accessing the mappings directly is more efficient
-    performedSwaps.setValue(_tokenA, _tokenB, _swapInterval, _swapToRegister);
-    nextSwapAvailable.setValue(_tokenA, _tokenB, _swapInterval, ((_timestamp / _swapInterval) + 1) * _swapInterval);
+    performedSwaps[_tokenA][_tokenB][_swapInterval] = _swapToRegister;
+    nextSwapAvailable[_tokenA][_tokenB][_swapInterval] = ((_timestamp / _swapInterval) + 1) * _swapInterval;
   }
 
   function _getAmountToSwap(
@@ -57,10 +56,10 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubParameters, IDCAHu
   }
 
   function _getNextSwapsToPerform() internal view virtual returns (SwapInformation[] memory _swapsToPerform, uint8 _amountOfSwapsToPerform) {
-    uint256 _activeSwapIntervalsLength = _activeSwapIntervals.length();
+    uint256 _activeSwapIntervalsLength = _activeSwapIntervals[address(tokenA)][address(tokenB)].length();
     _swapsToPerform = new SwapInformation[](_activeSwapIntervalsLength);
     for (uint256 i; i < _activeSwapIntervalsLength; i++) {
-      uint32 _swapInterval = uint32(_activeSwapIntervals.at(i));
+      uint32 _swapInterval = uint32(_activeSwapIntervals[address(tokenA)][address(tokenB)].at(i));
       if (nextSwapAvailable.getValue(address(tokenA), address(tokenB), _swapInterval) <= _getTimestamp()) {
         uint32 _swapToPerform = performedSwaps.getValue(address(tokenA), address(tokenB), _swapInterval) + 1;
         (uint256 _amountToSwapTokenA, uint256 _amountToSwapTokenB) = _getAmountToSwap(address(tokenA), address(tokenB), _swapInterval);
@@ -77,8 +76,8 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubParameters, IDCAHu
   function secondsUntilNextSwap() external view override returns (uint32 _secondsUntil) {
     _secondsUntil = type(uint32).max;
     uint32 _timestamp = _getTimestamp();
-    for (uint256 i; i < _activeSwapIntervals.length(); i++) {
-      uint32 _swapInterval = uint32(_activeSwapIntervals.at(i));
+    for (uint256 i; i < _activeSwapIntervals[address(tokenA)][address(tokenB)].length(); i++) {
+      uint32 _swapInterval = uint32(_activeSwapIntervals[address(tokenA)][address(tokenB)].at(i));
       uint32 _nextAvailable = nextSwapAvailable.getValue(address(tokenA), address(tokenB), _swapInterval);
       if (_nextAvailable <= _timestamp) {
         _secondsUntil = 0;
@@ -90,11 +89,6 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubParameters, IDCAHu
         }
       }
     }
-  }
-
-  function getNextSwapInfo() external view override returns (NextSwapInformation memory _nextSwapInformation) {
-    IDCAGlobalParameters.SwapParameters memory _swapParameters = globalParameters.swapParameters();
-    (_nextSwapInformation, , ) = _getNextSwapInfo(_swapParameters.swapFee, _swapParameters.oracle);
   }
 
   function _getNextSwapInfo(uint32 _swapFee, ITimeWeightedOracle _oracle)
@@ -188,7 +182,7 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubParameters, IDCAHu
         if (_nextSwapInformation.swapsToPerform[i].amountToSwapTokenA > 0 || _nextSwapInformation.swapsToPerform[i].amountToSwapTokenB > 0) {
           _registerSwap(address(tokenA), address(tokenB), _swapInterval, _ratePerUnitAToBWithFee, _ratePerUnitBToAWithFee, _timestamp);
         } else {
-          _activeSwapIntervals.remove(_swapInterval);
+          _activeSwapIntervals[address(tokenA)][address(tokenB)].remove(_swapInterval);
         }
       }
     }
@@ -261,31 +255,26 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubParameters, IDCAHu
     _blockTimestamp = uint32(block.timestamp);
   }
 
-  function _getTotalAmountsToSwap(
-    address _tokenA,
-    address _tokenB,
-    uint32[] memory _allowedSwapIntervals
-  )
+  function _getTotalAmountsToSwap(address _tokenA, address _tokenB)
     internal
     view
     virtual
     returns (
       uint256 _totalAmountToSwapTokenA,
       uint256 _totalAmountToSwapTokenB,
-      uint32[] memory _affectedIntervals
+      uint32[] memory _intervalsInSwap
     )
   {
     uint8 _intervalCount;
-    _affectedIntervals = new uint32[](_allowedSwapIntervals.length);
-    for (uint256 i; i < _allowedSwapIntervals.length; i++) {
-      uint32 _swapInterval = _allowedSwapIntervals[i];
+    EnumerableSet.UintSet storage _swapIntervals = _activeSwapIntervals[_tokenA][_tokenB];
+    _intervalsInSwap = new uint32[](_swapIntervals.length());
+    for (uint256 i; i < _swapIntervals.length(); i++) {
+      uint32 _swapInterval = uint32(_swapIntervals.at(i));
       if (nextSwapAvailable.getValue(_tokenA, _tokenB, _swapInterval) <= _getTimestamp()) {
         (uint256 _amountToSwapTokenA, uint256 _amountToSwapTokenB) = _getAmountToSwap(_tokenA, _tokenB, _swapInterval);
-        if (_amountToSwapTokenA > 0 || _amountToSwapTokenB > 0) {
-          _affectedIntervals[_intervalCount++] = _swapInterval;
-          _totalAmountToSwapTokenA += _amountToSwapTokenA;
-          _totalAmountToSwapTokenB += _amountToSwapTokenB;
-        }
+        _intervalsInSwap[_intervalCount++] = _swapInterval;
+        _totalAmountToSwapTokenA += _amountToSwapTokenA;
+        _totalAmountToSwapTokenB += _amountToSwapTokenB;
       }
     }
   }
@@ -354,13 +343,11 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubParameters, IDCAHu
     uint120 magnitudeB; // 36 decimals max amount supported
   }
 
-  // TODO: Check if using the "each pair's active intervals" approach is creaper
   function _getNextSwapInfo(
     address[] memory _tokens,
     PairIndexes[] memory _pairs,
     uint32 _swapFee,
-    ITimeWeightedOracle _oracle,
-    uint32[] memory _allowedSwapIntervals
+    ITimeWeightedOracle _oracle
   ) internal view virtual returns (SwapInfo memory _swapInformation, RatioWithFee[] memory _internalSwapInformation) {
     // TODO: Make sure that there are no repeated tokens in _tokens
     // TODO: Make sure that there are no repeted pairs in _pairs
@@ -386,8 +373,7 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubParameters, IDCAHu
 
       (_amountToSwapTokenA, _amountToSwapTokenB, _swapInformation.pairs[i].intervalsInSwap) = _getTotalAmountsToSwap(
         _swapInformation.pairs[i].tokenA,
-        _swapInformation.pairs[i].tokenB,
-        _allowedSwapIntervals
+        _swapInformation.pairs[i].tokenB
       );
 
       _total[_tokenInfo.indexTokenA] += _amountToSwapTokenA;
@@ -458,13 +444,7 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubParameters, IDCAHu
     returns (NextSwapInfo memory _swapInformation)
   {
     IDCAGlobalParameters.SwapParameters memory _swapParameters = globalParameters.swapParameters();
-    (SwapInfo memory _internalSwapInformation, ) = _getNextSwapInfo(
-      _tokens,
-      _pairsToSwap,
-      _swapParameters.swapFee,
-      _swapParameters.oracle,
-      globalParameters.allowedSwapIntervals()
-    );
+    (SwapInfo memory _internalSwapInformation, ) = _getNextSwapInfo(_tokens, _pairsToSwap, _swapParameters.swapFee, _swapParameters.oracle);
 
     _swapInformation.pairs = _internalSwapInformation.pairs;
     _swapInformation.tokens = new NextTokenInSwap[](_internalSwapInformation.tokens.length);

--- a/contracts/interfaces/IDCAHub.sol
+++ b/contracts/interfaces/IDCAHub.sol
@@ -20,12 +20,6 @@ interface IDCAHubParameters {
   /// @notice Returns the token B contract
   /// @return The contract for token B
   function tokenB() external view returns (IERC20Metadata);
-
-  /// @notice Returns if a certain swap interval is active or not
-  /// @dev We consider a swap interval to be active if there is at least one active position on that interval
-  /// @param _swapInterval The swap interval to check
-  /// @return _isActive Whether the given swap interval is currently active
-  function isSwapIntervalActive(uint32 _swapInterval) external view returns (bool _isActive);
 }
 
 /// @title The interface for all position related matters in a DCA pair
@@ -318,10 +312,6 @@ interface IDCAHubSwapHandler {
 
   /// @notice Thrown when trying to execute a swap, but none is available
   error NoSwapsToExecute();
-
-  /// @notice Returns all information related to the next swap
-  /// @return _nextSwapInformation The information about the next swap
-  function getNextSwapInfo() external view returns (NextSwapInformation memory _nextSwapInformation);
 
   /// @notice Executes a swap
   /// @dev This method assumes that the required amount has already been sent. Will revert with:

--- a/contracts/mocks/DCAHub/DCAHubParameters.sol
+++ b/contracts/mocks/DCAHub/DCAHubParameters.sol
@@ -36,12 +36,20 @@ contract DCAHubParametersMock is DCAHubParameters {
     _balances[_token] = _amount;
   }
 
-  function addActiveSwapInterval(uint32 _activeInterval) external {
-    _activeSwapIntervals.add(_activeInterval);
+  function addActiveSwapInterval(
+    address _tokenA,
+    address _tokenB,
+    uint32 _activeInterval
+  ) external {
+    _activeSwapIntervals[_tokenA][_tokenB].add(_activeInterval);
   }
 
-  function removeActiveSwapInterval(uint32 _activeInterval) external {
-    _activeSwapIntervals.remove(_activeInterval);
+  function removeActiveSwapInterval(
+    address _tokenA,
+    address _tokenB,
+    uint32 _activeInterval
+  ) external {
+    _activeSwapIntervals[_tokenA][_tokenB].remove(_activeInterval);
   }
 
   function setSwapAmountDelta(

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -14,7 +14,11 @@ import { getNodeUrl, accounts } from './utils/network';
 import 'tsconfig-paths/register';
 
 const networks: NetworksUserConfig = process.env.TEST
-  ? {}
+  ? {
+      hardhat: {
+        allowUnlimitedContractSize: true,
+      },
+    }
   : {
       hardhat: {
         forking: {

--- a/test/e2e/DCAHub/happy-path.spec.ts
+++ b/test/e2e/DCAHub/happy-path.spec.ts
@@ -20,6 +20,7 @@ import { contract } from '@test-utils/bdd';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signers';
 import { TokenContract } from '@test-utils/erc20';
 import { readArgFromEventOrFail } from '@test-utils/event-utils';
+import { buildSwapInput } from 'js-lib/swap-utils';
 
 contract('DCAHub', () => {
   describe('Full e2e test', () => {
@@ -327,8 +328,18 @@ contract('DCAHub', () => {
 
     async function swap({ swapper }: { swapper: SignerWithAddress }) {
       const nextSwapInfo = await getNextSwapInfo();
-      const tokenToProvide = nextSwapInfo.tokenToBeProvidedBySwapper === tokenA.address ? tokenA : tokenB;
-      await tokenToProvide.connect(swapper).transfer(DCAHub.address, nextSwapInfo.amountToBeProvidedBySwapper);
+      const [token0, token1] = nextSwapInfo.tokens;
+      let amountToProvide: BigNumber;
+      let tokenToProvide: string;
+      if (token0.toProvide.gt(token1.toProvide)) {
+        amountToProvide = token0.toProvide;
+        tokenToProvide = token0.token;
+      } else {
+        amountToProvide = token1.toProvide;
+        tokenToProvide = token1.token;
+      }
+      const token = { [tokenA.address]: tokenA, [tokenB.address]: tokenB }[tokenToProvide];
+      await token.connect(swapper).transfer(DCAHub.address, amountToProvide);
       await DCAHub.connect(swapper)['swap()']();
     }
 
@@ -344,13 +355,9 @@ contract('DCAHub', () => {
       return DCAHub.userPosition(position.id);
     }
 
-    async function getNextSwapInfo(): Promise<NextSwapInformation> {
-      const nextSwapInfo: NextSwapInformation & { amountOfSwaps: number } = await DCAHub['getNextSwapInfo()']();
-      return {
-        ...nextSwapInfo,
-        // Remove zeroed positions in array
-        swapsToPerform: nextSwapInfo.swapsToPerform.slice(0, nextSwapInfo.amountOfSwaps),
-      };
+    async function getNextSwapInfo() {
+      const { tokens, indexes } = buildSwapInput([{ tokenA: tokenA.address, tokenB: tokenB.address }]);
+      return DCAHub.getNextSwapInfo(tokens, indexes);
     }
 
     async function modifyRate(position: UserPositionDefinition, rate: number): Promise<void> {
@@ -424,16 +431,27 @@ contract('DCAHub', () => {
     }
 
     async function assertAmountsToSwapAre({ tokenA: expectedTokenA, tokenB: expectedTokenB }: { tokenA: number; tokenB: number }) {
-      const { swapsToPerform } = await getNextSwapInfo();
-      const totalTokenA = swapsToPerform.map(({ amountToSwapTokenA }) => amountToSwapTokenA).reduce(sumBN, constants.ZERO);
-      const totalTokenB = swapsToPerform.map(({ amountToSwapTokenB }) => amountToSwapTokenB).reduce(sumBN, constants.ZERO);
+      const nextSwapInfo = await getNextSwapInfo();
+      const { intervalsInSwap } = nextSwapInfo.pairs[0];
+      let totalTokenA = constants.ZERO;
+      let totalTokenB = constants.ZERO;
+
+      for (const interval of intervalsInSwap) {
+        const performedSwaps = await DCAHub.performedSwaps(tokenA.address, tokenB.address, interval);
+        totalTokenA = totalTokenA.add(await DCAHub.swapAmountDelta(tokenA.address, tokenB.address, interval, performedSwaps + 1));
+        totalTokenB = totalTokenB.add(await DCAHub.swapAmountDelta(tokenB.address, tokenA.address, interval, performedSwaps + 1));
+      }
+
       expect(totalTokenA).to.equal(tokenA.asUnits(expectedTokenA));
       expect(totalTokenB).to.equal(tokenB.asUnits(expectedTokenB));
     }
 
     async function assertIntervalsToSwapNowAre(...swapIntervals: number[]): Promise<void> {
       const nextSwapInfo = await getNextSwapInfo();
-      const intervals = nextSwapInfo.swapsToPerform.map(({ interval }) => interval);
+      const intervals = nextSwapInfo.pairs
+        .map(({ intervalsInSwap }) => intervalsInSwap)
+        .flat()
+        .filter((interval) => interval > 0);
       expect(intervals).to.eql(swapIntervals);
       if (swapIntervals.length > 0) {
         const secondsUntilNext = await DCAHub.secondsUntilNextSwap();

--- a/test/e2e/DCAHub/precision-breaker.spec.ts
+++ b/test/e2e/DCAHub/precision-breaker.spec.ts
@@ -9,6 +9,7 @@ import { contract, given, then, when } from '@test-utils/bdd';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signers';
 import { TokenContract } from '@test-utils/erc20';
 import { FakeContract, smock } from '@defi-wonderland/smock';
+import { buildSwapInput } from 'js-lib/swap-utils';
 
 contract('DCAHub', () => {
   describe('Precision breaker', () => {
@@ -92,20 +93,27 @@ contract('DCAHub', () => {
     });
 
     async function swap({ swapper }: { swapper: SignerWithAddress }) {
-      const nextSwapInfo = await getNextSwapInfo();
-      const tokenToProvide = nextSwapInfo.tokenToBeProvidedBySwapper === tokenA.address ? tokenA : tokenB;
-      await tokenToProvide.connect(swapper).transfer(DCAHub.address, nextSwapInfo.amountToBeProvidedBySwapper);
+      const { amountToBeProvidedBySwapper, tokenToBeProvidedBySwapper } = await getAmountToBeProvided();
+      await tokenToBeProvidedBySwapper.connect(swapper).transfer(DCAHub.address, amountToBeProvidedBySwapper);
       await DCAHub.connect(swapper)['swap()']();
     }
 
-    async function getNextSwapInfo(): Promise<NextSwapInformation> {
-      const nextSwapInfo: NextSwapInformation & { amountOfSwaps: number } = await DCAHub['getNextSwapInfo()']();
-      return {
-        ...nextSwapInfo,
-        // Remove zeroed positions in array
-        swapsToPerform: nextSwapInfo.swapsToPerform.slice(0, nextSwapInfo.amountOfSwaps),
-      };
+    async function getAmountToBeProvided(): Promise<{ tokenToBeProvidedBySwapper: TokenContract; amountToBeProvidedBySwapper: BigNumber }> {
+      const { tokens, indexes } = buildSwapInput([{ tokenA: tokenA.address, tokenB: tokenB.address }]);
+      const nextSwapInfo = await DCAHub.getNextSwapInfo(tokens, indexes);
+      const [token0, token1] = nextSwapInfo.tokens;
+      let amountToBeProvidedBySwapper: BigNumber;
+      let tokenToBeProvidedBySwapper: string;
+      if (token0.toProvide.gt(token1.toProvide)) {
+        amountToBeProvidedBySwapper = token0.toProvide;
+        tokenToBeProvidedBySwapper = token0.token;
+      } else {
+        amountToBeProvidedBySwapper = token1.toProvide;
+        tokenToBeProvidedBySwapper = token1.token;
+      }
+      return { amountToBeProvidedBySwapper, tokenToBeProvidedBySwapper: tokenToBeProvidedBySwapper === tokenA.address ? tokenA : tokenB };
     }
+
     async function setInitialBalance(
       hasAddress: HasAddress,
       { tokenA: amountTokenA, tokenB: amountTokenB }: { tokenA: number; tokenB: number }

--- a/test/unit/DCAHub/dca-hub-position-handler.spec.ts
+++ b/test/unit/DCAHub/dca-hub-position-handler.spec.ts
@@ -269,7 +269,7 @@ describe('DCAPositionHandler', () => {
       });
 
       then('interval is now active', async () => {
-        expect(await DCAPositionHandler.isSwapIntervalActive(SWAP_INTERVAL)).to.be.true;
+        expect(await DCAPositionHandler.isSwapIntervalActive(tokenA.address, tokenB.address, SWAP_INTERVAL)).to.be.true;
       });
 
       thenInternalBalancesAreTheSameAsTokenBalances();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2018",
+    "target": "es2019",
     "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,


### PR DESCRIPTION
We are now adding the public version of `getNextSwapInfo`. It's almost the same as the internal version, but it also exposes how much is available to borrow for the given tokens.

The idea is that when users call `getNextSwapInfo(tokens, pairIndexes)`, they can send tokens in `tokens` that are not in pairIndexes. These tokens will return 0 in `toProvide`, `reward` and `platformFee`, but they will return how much is available to borrow

_Note: tests for this PR fail because the contract size is too big. We start to reduce the contract's size in https://github.com/Mean-Finance/dca-v1.1/pull/29_