### PR TITLE
refactor: use active intervals approach

### DIFF
--- a/contracts/DCAHub/DCAHubPositionHandler.sol
+++ b/contracts/DCAHub/DCAHubPositionHandler.sol
@@ -53,13 +53,15 @@ abstract contract DCAHubPositionHandler is ReentrancyGuard, DCAHubParameters, ID
     if (_owner == address(0)) revert CommonErrors.ZeroAddress();
     if (_tokenAddress != address(tokenA) && _tokenAddress != address(tokenB)) revert InvalidToken();
     if (_amountOfSwaps == 0) revert ZeroSwaps();
-    if (!_activeSwapIntervals.contains(_swapInterval) && !globalParameters.isSwapIntervalAllowed(_swapInterval)) revert InvalidInterval();
+    if (
+      !_activeSwapIntervals[address(tokenA)][address(tokenB)].contains(_swapInterval) && !globalParameters.isSwapIntervalAllowed(_swapInterval)
+    ) revert InvalidInterval();
     uint256 _amount = _rate * _amountOfSwaps;
     IERC20Metadata(_tokenAddress).safeTransferFrom(msg.sender, address(this), _amount);
     _balances[_tokenAddress] += _amount;
     _idCounter += 1;
     _safeMint(_owner, _idCounter);
-    _activeSwapIntervals.add(_swapInterval);
+    _activeSwapIntervals[address(tokenA)][address(tokenB)].add(_swapInterval);
     (uint32 _startingSwap, uint32 _finalSwap) = _addPosition(
       _idCounter,
       _tokenAddress,

--- a/contracts/interfaces/IDCAHub.sol
+++ b/contracts/interfaces/IDCAHub.sol
@@ -20,12 +20,6 @@ interface IDCAHubParameters {
   /// @notice Returns the token B contract
   /// @return The contract for token B
   function tokenB() external view returns (IERC20Metadata);
-
-  /// @notice Returns if a certain swap interval is active or not
-  /// @dev We consider a swap interval to be active if there is at least one active position on that interval
-  /// @param _swapInterval The swap interval to check
-  /// @return _isActive Whether the given swap interval is currently active
-  function isSwapIntervalActive(uint32 _swapInterval) external view returns (bool _isActive);
 }
 
 /// @title The interface for all position related matters in a DCA pair

--- a/contracts/mocks/DCAHub/DCAHubParameters.sol
+++ b/contracts/mocks/DCAHub/DCAHubParameters.sol
@@ -36,12 +36,20 @@ contract DCAHubParametersMock is DCAHubParameters {
     _balances[_token] = _amount;
   }
 
-  function addActiveSwapInterval(uint32 _activeInterval) external {
-    _activeSwapIntervals.add(_activeInterval);
+  function addActiveSwapInterval(
+    address _tokenA,
+    address _tokenB,
+    uint32 _activeInterval
+  ) external {
+    _activeSwapIntervals[_tokenA][_tokenB].add(_activeInterval);
   }
 
-  function removeActiveSwapInterval(uint32 _activeInterval) external {
-    _activeSwapIntervals.remove(_activeInterval);
+  function removeActiveSwapInterval(
+    address _tokenA,
+    address _tokenB,
+    uint32 _activeInterval
+  ) external {
+    _activeSwapIntervals[_tokenA][_tokenB].remove(_activeInterval);
   }
 
   function setSwapAmountDelta(

--- a/test/unit/DCAHub/dca-hub-position-handler.spec.ts
+++ b/test/unit/DCAHub/dca-hub-position-handler.spec.ts
@@ -269,7 +269,7 @@ describe('DCAPositionHandler', () => {
       });
 
       then('interval is now active', async () => {
-        expect(await DCAPositionHandler.isSwapIntervalActive(SWAP_INTERVAL)).to.be.true;
+        expect(await DCAPositionHandler.isSwapIntervalActive(tokenA.address, tokenB.address, SWAP_INTERVAL)).to.be.true;
       });
 
       thenInternalBalancesAreTheSameAsTokenBalances();


### PR DESCRIPTION
Before this change, the new `getNextSwapInfo` would take all available swap intervals, and iterate through all of them. Now, we are using the "active intervals" approach, as we did on the old version of `getNextSwapInfo`