### PR TITLE
refactor: rename rate per unit to ratio

### DIFF
--- a/contracts/DCAHub/DCAHubParameters.sol
+++ b/contracts/DCAHub/DCAHubParameters.sol
@@ -39,7 +39,7 @@ abstract contract DCAHubParameters is IDCAHubParameters {
   // Tracking
   // TODO: See if there is a way to optimize all these mappings
   mapping(address => mapping(address => mapping(uint32 => mapping(uint32 => int256)))) public swapAmountDelta; // from token => to token => swap interval => swap number => delta
-  mapping(address => mapping(address => mapping(uint32 => mapping(uint32 => uint256)))) internal _accumRatesPerUnit; // from token => to token => swap interval => swap number => accum
+  mapping(address => mapping(address => mapping(uint32 => mapping(uint32 => uint256)))) public accumRatio; // from token => to token => swap interval => swap number => accum
 
   mapping(address => mapping(address => mapping(uint32 => uint32))) public performedSwaps; // token A => token B => swap interval => performed swaps
   mapping(address => mapping(address => mapping(uint32 => uint32))) public nextSwapAvailable; // token A => token B => swap interval => timestamp

--- a/contracts/DCAHub/DCAHubPositionHandler.sol
+++ b/contracts/DCAHub/DCAHubPositionHandler.sol
@@ -293,9 +293,8 @@ abstract contract DCAHubPositionHandler is ReentrancyGuard, DCAHubParameters, ID
       return _userDCA.swappedBeforeModified;
     }
 
-    uint256 _accumRatesfinalSwap = _accumRatesPerUnit[_userDCA.from][_userDCA.to][_userDCA.swapInterval][_newestSwapToConsider];
-    uint256 _accumPerUnit = _accumRatesfinalSwap -
-      _accumRatesPerUnit[_userDCA.from][_userDCA.to][_userDCA.swapInterval][_userDCA.swapWhereLastUpdated];
+    uint256 _accumRatiosFinalSwap = accumRatio[_userDCA.from][_userDCA.to][_userDCA.swapInterval][_newestSwapToConsider];
+    uint256 _accumPerUnit = _accumRatiosFinalSwap - accumRatio[_userDCA.from][_userDCA.to][_userDCA.swapInterval][_userDCA.swapWhereLastUpdated];
     uint256 _magnitude = 10**IERC20Metadata(_userDCA.from).decimals();
     (bool _ok, uint256 _mult) = Math.tryMul(_accumPerUnit, _userDCA.rate);
     uint256 _swappedInCurrentPosition = _ok ? _mult / _magnitude : (_accumPerUnit / _magnitude) * _userDCA.rate;

--- a/contracts/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/DCAHub/DCAHubSwapHandler.sol
@@ -16,20 +16,20 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubParameters, IDCAHu
     address _tokenA,
     address _tokenB,
     uint32 _swapInterval,
-    uint256 _ratePerUnitAToB,
-    uint256 _ratePerUnitBToA,
+    uint256 _ratioAToB,
+    uint256 _ratioBToA,
     uint32 _timestamp
   ) internal virtual {
     uint32 _swapToRegister = performedSwaps[_tokenA][_tokenB][_swapInterval] + 1;
     int256 _swappedTokenA = swapAmountDelta[_tokenA][_tokenB][_swapInterval][_swapToRegister];
     int256 _swappedTokenB = swapAmountDelta[_tokenB][_tokenA][_swapInterval][_swapToRegister];
     if (_swappedTokenA > 0 || _swappedTokenB > 0) {
-      _accumRatesPerUnit[_tokenA][_tokenB][_swapInterval][_swapToRegister] =
-        _accumRatesPerUnit[_tokenA][_tokenB][_swapInterval][_swapToRegister - 1] +
-        _ratePerUnitAToB;
-      _accumRatesPerUnit[_tokenB][_tokenA][_swapInterval][_swapToRegister] =
-        _accumRatesPerUnit[_tokenB][_tokenA][_swapInterval][_swapToRegister - 1] +
-        _ratePerUnitBToA;
+      accumRatio[_tokenA][_tokenB][_swapInterval][_swapToRegister] =
+        accumRatio[_tokenA][_tokenB][_swapInterval][_swapToRegister - 1] +
+        _ratioAToB;
+      accumRatio[_tokenB][_tokenA][_swapInterval][_swapToRegister] =
+        accumRatio[_tokenB][_tokenA][_swapInterval][_swapToRegister - 1] +
+        _ratioBToA;
       swapAmountDelta[_tokenA][_tokenB][_swapInterval][_swapToRegister + 1] += _swappedTokenA;
       swapAmountDelta[_tokenB][_tokenA][_swapInterval][_swapToRegister + 1] += _swappedTokenB;
       delete swapAmountDelta[_tokenA][_tokenB][_swapInterval][_swapToRegister];

--- a/contracts/interfaces/IDCAHub.sol
+++ b/contracts/interfaces/IDCAHub.sol
@@ -254,46 +254,6 @@ interface IDCAHubPositionHandler is IERC721, IDCAHubParameters {
 /// @title The interface for all swap related matters in a DCA pair
 /// @notice These methods allow users to get information about the next swap, and how to execute it
 interface IDCAHubSwapHandler {
-  /// @notice Information about an available swap for a specific swap interval
-  struct SwapInformation {
-    // The affected swap interval
-    uint32 interval;
-    // The number of the swap that will be performed
-    uint32 swapToPerform;
-    // The amount of token A that needs swapping
-    uint256 amountToSwapTokenA;
-    // The amount of token B that needs swapping
-    uint256 amountToSwapTokenB;
-  }
-
-  /// @notice All information about the next swap
-  struct NextSwapInformation {
-    // All swaps that can be executed
-    SwapInformation[] swapsToPerform;
-    // How many entries of the swapsToPerform array are valid
-    uint8 amountOfSwaps;
-    // How much can be borrowed in token A during a flash swap
-    uint256 availableToBorrowTokenA;
-    // How much can be borrowed in token B during a flash swap
-    uint256 availableToBorrowTokenB;
-    // How much 10**decimals(tokenB) is when converted to token A
-    uint256 ratePerUnitBToA;
-    // How much 10**decimals(tokenA) is when converted to token B
-    uint256 ratePerUnitAToB;
-    // How much token A will be sent to the platform in terms of fee
-    uint256 platformFeeTokenA;
-    // How much token B will be sent to the platform in terms of fee
-    uint256 platformFeeTokenB;
-    // The amount of tokens that need to be provided by the swapper
-    uint256 amountToBeProvidedBySwapper;
-    // The amount of tokens that will be sent to the swapper optimistically
-    uint256 amountToRewardSwapperWith;
-    // The token that needs to be provided by the swapper
-    IERC20Metadata tokenToBeProvidedBySwapper;
-    // The token that will be sent to the swapper optimistically
-    IERC20Metadata tokenToRewardSwapperWith;
-  }
-
   struct TokenInSwap {
     address token;
     uint256 reward;

--- a/contracts/mocks/DCAHub/DCAHubParameters.sol
+++ b/contracts/mocks/DCAHub/DCAHubParameters.sol
@@ -66,23 +66,14 @@ contract DCAHubParametersMock is DCAHubParameters {
     swapAmountDelta[_from][_to][_swapInterval][_swap] = _value;
   }
 
-  function setAcummRatesPerUnit(
-    uint32 _swapInterval,
+  function setAcummRatio(
     address _from,
     address _to,
+    uint32 _swapInterval,
     uint32 _swap,
-    uint256 _accumRatePerUnit
+    uint256 _accumRatio
   ) external {
-    _accumRatesPerUnit[_from][_to][_swapInterval][_swap] = _accumRatePerUnit;
-  }
-
-  function accumRatesPerUnit(
-    uint32 _swapInterval,
-    address _from,
-    address _to,
-    uint32 _swap
-  ) external view returns (uint256) {
-    return _accumRatesPerUnit[_from][_to][_swapInterval][_swap];
+    accumRatio[_from][_to][_swapInterval][_swap] = _accumRatio;
   }
 
   function setPerformedSwaps(uint32 _swapInterval, uint32 _performedSwaps) external {
@@ -92,16 +83,6 @@ contract DCAHubParametersMock is DCAHubParameters {
     } else {
       performedSwaps[address(tokenB)][address(tokenA)][_swapInterval] = _performedSwaps;
     }
-  }
-
-  function setRatePerUnit(
-    uint32 _swapInterval,
-    address _from,
-    address _to,
-    uint32 _swap,
-    uint256 _rate
-  ) external {
-    _accumRatesPerUnit[_from][_to][_swapInterval][_swap] = _rate;
   }
 
   function getFeeFromAmount(uint32 _feeAmount, uint256 _amount) external view returns (uint256) {

--- a/contracts/mocks/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/mocks/DCAHub/DCAHubSwapHandler.sol
@@ -6,8 +6,8 @@ import './DCAHubParameters.sol';
 
 contract DCAHubSwapHandlerMock is DCAHubSwapHandler, DCAHubParametersMock {
   struct RegisterSwapCall {
-    uint256 ratePerUnitAToB;
-    uint256 ratePerUnitBToA;
+    uint256 ratioAToB;
+    uint256 ratioBToA;
     uint32 timestamp;
   }
 
@@ -41,11 +41,11 @@ contract DCAHubSwapHandlerMock is DCAHubSwapHandler, DCAHubParametersMock {
     address _tokenA,
     address _tokenB,
     uint32 _swapInterval,
-    uint256 _ratePerUnitAToB,
-    uint256 _ratePerUnitBToA,
+    uint256 _ratioAToB,
+    uint256 _ratioBToA,
     uint32 _timestamp
   ) external {
-    _registerSwap(_tokenA, _tokenB, _swapInterval, _ratePerUnitAToB, _ratePerUnitBToA, _timestamp);
+    _registerSwap(_tokenA, _tokenB, _swapInterval, _ratioAToB, _ratioBToA, _timestamp);
   }
 
   function getAmountToSwap(
@@ -182,16 +182,12 @@ contract DCAHubSwapHandlerMock is DCAHubSwapHandler, DCAHubParametersMock {
     address _tokenA,
     address _tokenB,
     uint32 _swapInterval,
-    uint256 _ratePerUnitAToB,
-    uint256 _ratePerUnitBToA,
+    uint256 _ratioAToB,
+    uint256 _ratioBToA,
     uint32 _timestamp
   ) internal override {
-    registerSwapCalls[_tokenA][_tokenB][_swapInterval] = RegisterSwapCall({
-      ratePerUnitAToB: _ratePerUnitAToB,
-      ratePerUnitBToA: _ratePerUnitBToA,
-      timestamp: _timestamp
-    });
-    super._registerSwap(_tokenA, _tokenB, _swapInterval, _ratePerUnitAToB, _ratePerUnitBToA, _timestamp);
+    registerSwapCalls[_tokenA][_tokenB][_swapInterval] = RegisterSwapCall({ratioAToB: _ratioAToB, ratioBToA: _ratioBToA, timestamp: _timestamp});
+    super._registerSwap(_tokenA, _tokenB, _swapInterval, _ratioAToB, _ratioBToA, _timestamp);
   }
 
   // Mocks setters

--- a/test/e2e/DCAHub/happy-path.spec.ts
+++ b/test/e2e/DCAHub/happy-path.spec.ts
@@ -572,27 +572,6 @@ contract('DCAHub', () => {
 
     type SwapRatio = { tokenA: 1; tokenB: number } | { tokenA: number; tokenB: 1 };
 
-    type SwapInformation = {
-      interval: number;
-      swapToPerform: number;
-      amountToSwapTokenA: BigNumber;
-      amountToSwapTokenB: BigNumber;
-    };
-
-    type NextSwapInformation = {
-      swapsToPerform: SwapInformation[];
-      availableToBorrowTokenA: BigNumber;
-      availableToBorrowTokenB: BigNumber;
-      ratePerUnitBToA: BigNumber;
-      ratePerUnitAToB: BigNumber;
-      platformFeeTokenA: BigNumber;
-      platformFeeTokenB: BigNumber;
-      amountToBeProvidedBySwapper: BigNumber;
-      amountToRewardSwapperWith: BigNumber;
-      tokenToBeProvidedBySwapper: string;
-      tokenToRewardSwapperWith: string;
-    };
-
     type UserPositionDefinition = {
       id: BigNumber;
       owner: SignerWithAddress;

--- a/test/e2e/DCAHub/precision-breaker.spec.ts
+++ b/test/e2e/DCAHub/precision-breaker.spec.ts
@@ -124,27 +124,6 @@ contract('DCAHub', () => {
       await tokenB.mint(hasAddress.address, tokenB.asUnits(amountTokenB));
     }
 
-    type SwapInformation = {
-      interval: number;
-      swapToPerform: number;
-      amountToSwapTokenA: BigNumber;
-      amountToSwapTokenB: BigNumber;
-    };
-
-    type NextSwapInformation = {
-      swapsToPerform: SwapInformation[];
-      availableToBorrowTokenA: BigNumber;
-      availableToBorrowTokenB: BigNumber;
-      ratePerUnitBToA: BigNumber;
-      ratePerUnitAToB: BigNumber;
-      platformFeeTokenA: BigNumber;
-      platformFeeTokenB: BigNumber;
-      amountToBeProvidedBySwapper: BigNumber;
-      amountToRewardSwapperWith: BigNumber;
-      tokenToBeProvidedBySwapper: string;
-      tokenToRewardSwapperWith: string;
-    };
-
     type HasAddress = {
       readonly address: string;
     };

--- a/test/unit/DCAHub/dca-hub-position-handler.spec.ts
+++ b/test/unit/DCAHub/dca-hub-position-handler.spec.ts
@@ -340,7 +340,7 @@ describe('DCAPositionHandler', () => {
         ({ dcaId } = await deposit({ owner: owner.address, token: tokenA, rate: POSITION_RATE_5, swaps: POSITION_SWAPS_TO_PERFORM_10 }));
         await performTrade({
           swap: PERFORMED_SWAPS_10 + 1,
-          ratePerUnit: RATE_PER_UNIT_5,
+          ratio: RATE_PER_UNIT_5,
           amount: POSITION_RATE_5,
         });
       });
@@ -485,13 +485,13 @@ describe('DCAPositionHandler', () => {
         }));
         await performTrade({
           swap: PERFORMED_SWAPS_10 + 1,
-          ratePerUnit: RATE_PER_UNIT_5,
+          ratio: RATE_PER_UNIT_5,
           amount: POSITION_RATE_5,
           fromToken: tokenA,
         });
         await performTrade({
           swap: PERFORMED_SWAPS_10 + 1,
-          ratePerUnit: RATE_PER_UNIT_5,
+          ratio: RATE_PER_UNIT_5,
           amount: POSITION_RATE_3,
           fromToken: tokenB,
         });
@@ -588,7 +588,7 @@ describe('DCAPositionHandler', () => {
 
         await performTrade({
           swap: PERFORMED_SWAPS_10 + 1,
-          ratePerUnit: RATE_PER_UNIT_5,
+          ratio: RATE_PER_UNIT_5,
           amount: POSITION_RATE_5,
         });
 
@@ -672,7 +672,7 @@ describe('DCAPositionHandler', () => {
         // Execute first swap
         await performTrade({
           swap: PERFORMED_SWAPS_10 + 1,
-          ratePerUnit: RATE_PER_UNIT_5,
+          ratio: RATE_PER_UNIT_5,
           amount: POSITION_RATE_5,
         });
 
@@ -682,7 +682,7 @@ describe('DCAPositionHandler', () => {
         // Execute second swap
         await performTrade({
           swap: PERFORMED_SWAPS_10 + 2,
-          ratePerUnit: RATE_PER_UNIT_5 * 2,
+          ratio: RATE_PER_UNIT_5 * 2,
           amount: POSITION_RATE_6,
         });
 
@@ -692,7 +692,7 @@ describe('DCAPositionHandler', () => {
         // Execute final swap
         await performTrade({
           swap: PERFORMED_SWAPS_10 + 3,
-          ratePerUnit: RATE_PER_UNIT_5 * 3,
+          ratio: RATE_PER_UNIT_5 * 3,
           amount: POSITION_RATE_7,
         });
 
@@ -901,7 +901,7 @@ describe('DCAPositionHandler', () => {
 
         await performTrade({
           swap: PERFORMED_SWAPS_10 + 1,
-          ratePerUnit: RATE_PER_UNIT_5,
+          ratio: RATE_PER_UNIT_5,
           amount: POSITION_RATE_5,
         });
 
@@ -922,7 +922,7 @@ describe('DCAPositionHandler', () => {
       given(async () => {
         const { dcaId } = await deposit({ owner: owner.address, token: tokenA, rate: 1, swaps: 1 });
         await DCAPositionHandler.setPerformedSwaps(SWAP_INTERVAL, PERFORMED_SWAPS_10 + 1);
-        await setRatePerUnit({
+        await setRatio({
           accumRate: constants.MAX_UINT_256,
           onSwap: PERFORMED_SWAPS_10 + 1,
         });
@@ -945,13 +945,13 @@ describe('DCAPositionHandler', () => {
         const { dcaId } = await deposit({ owner: owner.address, token: tokenA, rate: 1, swaps: 1 });
 
         // Set a value in PERFORMED_SWAPS_10 + 1
-        await setRatePerUnit({
+        await setRatio({
           accumRate: 1000000,
           onSwap: PERFORMED_SWAPS_10 + 1,
         });
 
         // Set another value in PERFORMED_SWAPS_10 + 2
-        await setRatePerUnit({
+        await setRatio({
           accumRate: 1000001,
           onSwap: PERFORMED_SWAPS_10 + 2,
         });
@@ -969,13 +969,13 @@ describe('DCAPositionHandler', () => {
         const { dcaId } = await deposit({ owner: owner.address, token: tokenA, rate: 1, swaps: 1 });
 
         // Set a value in PERFORMED_SWAPS_10 + 1
-        await setRatePerUnit({
+        await setRatio({
           accumRate: 1000000,
           onSwap: PERFORMED_SWAPS_10 + 1,
         });
 
         // Set another value in PERFORMED_SWAPS_10 + 2
-        await setRatePerUnit({
+        await setRatio({
           accumRate: 1000001,
           onSwap: PERFORMED_SWAPS_10 + 2,
         });
@@ -1015,7 +1015,7 @@ describe('DCAPositionHandler', () => {
     async function calculateSwappedWith({ accumRate, positionRate }: { accumRate: number | BigNumber; positionRate?: number }) {
       const { dcaId } = await deposit({ owner: owner.address, token: tokenA, rate: positionRate ?? 1, swaps: 1 });
       await DCAPositionHandler.setPerformedSwaps(SWAP_INTERVAL, PERFORMED_SWAPS_10 + 1);
-      await setRatePerUnit({
+      await setRatio({
         accumRate,
         onSwap: PERFORMED_SWAPS_10 + 1,
       });
@@ -1026,7 +1026,7 @@ describe('DCAPositionHandler', () => {
     async function expectCalculationToFailWithOverflow({ accumRate, positionRate }: { accumRate: number | BigNumber; positionRate: number }) {
       const { dcaId } = await deposit({ owner: owner.address, token: tokenA, rate: positionRate ?? 1, swaps: 1 });
       await DCAPositionHandler.setPerformedSwaps(SWAP_INTERVAL, PERFORMED_SWAPS_10 + 1);
-      await setRatePerUnit({
+      await setRatio({
         accumRate,
         onSwap: PERFORMED_SWAPS_10 + 1,
       });
@@ -1039,11 +1039,11 @@ describe('DCAPositionHandler', () => {
     }
   });
 
-  async function setRatePerUnit({ accumRate, onSwap }: { accumRate: number | BigNumber; onSwap: number }) {
-    await DCAPositionHandler.setRatePerUnit(
-      SWAP_INTERVAL,
+  async function setRatio({ accumRate, onSwap }: { accumRate: number | BigNumber; onSwap: number }) {
+    await DCAPositionHandler.setAcummRatio(
       tokenA.address,
       tokenB.address,
+      SWAP_INTERVAL,
       onSwap,
       BigNumber.isBigNumber(accumRate) ? accumRate : tokenB.asUnits(accumRate)
     );
@@ -1126,7 +1126,7 @@ describe('DCAPositionHandler', () => {
 
         await performTrade({
           swap: PERFORMED_SWAPS_10 + 1,
-          ratePerUnit: RATE_PER_UNIT_5,
+          ratio: RATE_PER_UNIT_5,
           amount: initialRate,
         });
 
@@ -1204,23 +1204,13 @@ describe('DCAPositionHandler', () => {
     });
   }
 
-  async function performTrade({
-    swap,
-    ratePerUnit,
-    amount,
-    fromToken,
-  }: {
-    swap: number;
-    ratePerUnit: number;
-    amount: number;
-    fromToken?: TokenContract;
-  }) {
+  async function performTrade({ swap, ratio, amount, fromToken }: { swap: number; ratio: number; amount: number; fromToken?: TokenContract }) {
     const fromTokenReal = fromToken ?? tokenA;
     const toToken = fromTokenReal === tokenA ? tokenB : tokenA;
     await DCAPositionHandler.setPerformedSwaps(SWAP_INTERVAL, swap);
-    await DCAPositionHandler.setRatePerUnit(SWAP_INTERVAL, fromTokenReal.address, toToken.address, swap, toToken.asUnits(ratePerUnit));
+    await DCAPositionHandler.setAcummRatio(fromTokenReal.address, toToken.address, SWAP_INTERVAL, swap, toToken.asUnits(ratio));
     await fromTokenReal.burn(DCAPositionHandler.address, fromTokenReal.asUnits(amount));
-    await toToken.mint(DCAPositionHandler.address, toToken.asUnits(amount * ratePerUnit));
+    await toToken.mint(DCAPositionHandler.address, toToken.asUnits(amount * ratio));
     await DCAPositionHandler.setInternalBalances(
       await tokenA.balanceOf(DCAPositionHandler.address),
       await tokenB.balanceOf(DCAPositionHandler.address)


### PR DESCRIPTION
We are doing two things here:
1. We are renaming "rate per unit" to "ratio", so we can differentiate it more easily with the position's rate
2. We are making what used to be "_accumRatesPerUnit" public