### PR TITLE
feat: multi pair support for seconds until next swap

### DIFF
--- a/contracts/DCAHub/DCAHubPositionHandler.sol
+++ b/contracts/DCAHub/DCAHubPositionHandler.sol
@@ -93,6 +93,7 @@ abstract contract DCAHubPositionHandler is ReentrancyGuard, DCAHubParameters, ID
     emit Withdrew(msg.sender, _recipient, _dcaId, _to, _swapped);
   }
 
+  // { to: token, ids: BigNumber[] }[]
   function withdrawSwappedMany(uint256[] calldata _dcaIds, address _recipient)
     external
     override

--- a/contracts/interfaces/IDCAHub.sol
+++ b/contracts/interfaces/IDCAHub.sol
@@ -263,10 +263,6 @@ interface IDCAHubSwapHandler {
 
   /// @notice Thrown when trying to execute a swap, but none is available
   error NoSwapsToExecute();
-
-  /// @notice Returns how many seconds left until the next swap is available
-  /// @return _secondsUntilNextSwap The amount of seconds until next swap. Returns 0 if a swap can already be executed
-  function secondsUntilNextSwap() external view returns (uint32 _secondsUntilNextSwap);
 }
 
 /// @title The interface for all loan related matters in a DCA pair

--- a/contracts/mocks/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/mocks/DCAHub/DCAHubSwapHandler.sol
@@ -109,8 +109,8 @@ contract DCAHubSwapHandlerMock is DCAHubSwapHandler, DCAHubParametersMock {
   }
 
   function internalGetNextSwapInfo(
-    address[] memory _tokens,
-    PairIndexes[] memory _pairs,
+    address[] calldata _tokens,
+    PairIndexes[] calldata _pairs,
     uint32 _swapFee,
     ITimeWeightedOracle _oracle
   ) external view returns (SwapInfo memory, RatioWithFee[] memory) {
@@ -118,8 +118,8 @@ contract DCAHubSwapHandlerMock is DCAHubSwapHandler, DCAHubParametersMock {
   }
 
   function _getNextSwapInfo(
-    address[] memory _tokens,
-    PairIndexes[] memory _pairs,
+    address[] calldata _tokens,
+    PairIndexes[] calldata _pairs,
     uint32 _swapFee,
     ITimeWeightedOracle _oracle
   ) internal view override returns (SwapInfo memory, RatioWithFee[] memory) {

--- a/test/e2e/DCAHub/happy-path.spec.ts
+++ b/test/e2e/DCAHub/happy-path.spec.ts
@@ -436,12 +436,12 @@ contract('DCAHub', () => {
     }
 
     async function assertNoSwapsCanBeExecutedNow() {
-      const secondsUntilNext = await DCAHub.secondsUntilNextSwap();
+      const [secondsUntilNext] = await DCAHub.secondsUntilNextSwap([{ tokenA: tokenA.address, tokenB: tokenB.address }]);
       expect(secondsUntilNext).to.be.greaterThan(0);
     }
 
     async function assertThereAreNoSwapsAvailable() {
-      const secondsUntilNext = await DCAHub.secondsUntilNextSwap();
+      const [secondsUntilNext] = await DCAHub.secondsUntilNextSwap([{ tokenA: tokenA.address, tokenB: tokenB.address }]);
       expect(secondsUntilNext).to.equal(MAX_UINT_32);
       await assertIntervalsToSwapNowAre();
     }
@@ -470,7 +470,7 @@ contract('DCAHub', () => {
         .filter((interval) => interval > 0);
       expect(intervals).to.eql(swapIntervals);
       if (swapIntervals.length > 0) {
-        const secondsUntilNext = await DCAHub.secondsUntilNextSwap();
+        const [secondsUntilNext] = await DCAHub.secondsUntilNextSwap([{ tokenA: tokenA.address, tokenB: tokenB.address }]);
         expect(secondsUntilNext).to.equal(0);
       }
     }

--- a/test/unit/DCAHub/dca-hub-swap-handler.spec.ts
+++ b/test/unit/DCAHub/dca-hub-swap-handler.spec.ts
@@ -1439,67 +1439,117 @@ describe('DCAHubSwapHandler', () => {
 
   describe('secondsUntilNextSwap', () => {
     secondsUntilNextSwapTest({
-      title: 'there are not active intervals',
-      intervals: [],
-      blockTimestamp: 1000,
-      expected: 2 ** 32 - 1,
+      title: 'no pairs are passed',
+      pairs: [],
+      currentTimestamp: 1000,
+      expected: [],
     });
 
     secondsUntilNextSwapTest({
-      title: 'one of the intervals can be swapped already',
-      intervals: [
+      title: 'there are not active intervals for the given pair',
+      pairs: [
         {
-          interval: SWAP_INTERVAL,
-          nextAvailable: 1000,
-        },
-        {
-          interval: SWAP_INTERVAL_2,
-          nextAvailable: 1001,
+          tokenA: () => tokenA,
+          tokenB: () => tokenB,
+          intervals: [],
         },
       ],
-      blockTimestamp: 1000,
-      expected: 0,
+      currentTimestamp: 1000,
+      expected: [2 ** 32 - 1],
     });
 
     secondsUntilNextSwapTest({
-      title: 'none of the intervals can be swapped right now',
-      intervals: [
+      title: 'one of the intervals can be swapped for the given pair',
+      pairs: [
         {
-          interval: SWAP_INTERVAL,
-          nextAvailable: 1500,
-        },
-        {
-          interval: SWAP_INTERVAL_2,
-          nextAvailable: 1200,
+          tokenA: () => tokenA,
+          tokenB: () => tokenB,
+          intervals: [
+            {
+              interval: SWAP_INTERVAL,
+              nextAvailable: 1000,
+            },
+            {
+              interval: SWAP_INTERVAL_2,
+              nextAvailable: 1001,
+            },
+          ],
         },
       ],
-      blockTimestamp: 1000,
-      expected: 200,
+      currentTimestamp: 1000,
+      expected: [0],
+    });
+
+    secondsUntilNextSwapTest({
+      title: 'none of the intervals can be swapped right now for the given pair',
+      pairs: [
+        {
+          tokenA: () => tokenA,
+          tokenB: () => tokenB,
+          intervals: [
+            {
+              interval: SWAP_INTERVAL,
+              nextAvailable: 1500,
+            },
+            {
+              interval: SWAP_INTERVAL_2,
+              nextAvailable: 1200,
+            },
+          ],
+        },
+      ],
+      currentTimestamp: 1000,
+      expected: [200],
+    });
+
+    secondsUntilNextSwapTest({
+      title: 'many pairs are provided',
+      pairs: [
+        {
+          tokenA: () => tokenA,
+          tokenB: () => tokenB,
+          intervals: [{ interval: SWAP_INTERVAL_2, nextAvailable: 1200 }],
+        },
+        {
+          tokenA: () => tokenA,
+          tokenB: () => tokenC,
+          intervals: [{ interval: SWAP_INTERVAL, nextAvailable: 500 }],
+        },
+      ],
+      currentTimestamp: 1000,
+      expected: [200, 0],
     });
 
     async function secondsUntilNextSwapTest({
       title,
-      intervals,
-      blockTimestamp,
+      pairs,
+      currentTimestamp,
       expected,
     }: {
       title: string;
-      intervals: { interval: number; nextAvailable: number }[];
-      blockTimestamp: number;
-      expected: number;
+      pairs: {
+        tokenA: () => TokenContract;
+        tokenB: () => TokenContract;
+        intervals: { interval: number; nextAvailable: number }[];
+      }[];
+      currentTimestamp: number;
+      expected: number[];
     }) {
       when(title, () => {
         given(async () => {
-          for (const { interval, nextAvailable } of intervals) {
-            await DCAHubSwapHandler.addActiveSwapInterval(tokenA.address, tokenB.address, interval);
-            await DCAHubSwapHandler.setNextSwapAvailable(interval, nextAvailable);
+          for (const { tokenA, tokenB, intervals } of pairs) {
+            for (const { interval, nextAvailable } of intervals) {
+              await DCAHubSwapHandler.addActiveSwapInterval(tokenA().address, tokenB().address, interval);
+              await DCAHubSwapHandler.setNextSwapAvailable(interval, nextAvailable);
+            }
           }
-          await DCAHubSwapHandler.setBlockTimestamp(blockTimestamp);
+          await DCAHubSwapHandler.setBlockTimestamp(currentTimestamp);
         });
 
         then('result is as expected', async () => {
-          const result = await DCAHubSwapHandler.secondsUntilNextSwap();
-          expect(result).to.equal(expected);
+          const input = pairs.map(({ tokenA, tokenB }) => ({ tokenA: tokenA().address, tokenB: tokenB().address }));
+          const result = await DCAHubSwapHandler.secondsUntilNextSwap(input);
+          expect(result).to.eql(expected);
         });
       });
     }
@@ -1525,12 +1575,6 @@ describe('DCAHubSwapHandler', () => {
         threshold,
       });
     });
-  }
-
-  function toBN(amount: BigNumber | string | number, token: TokenContract): BigNumber {
-    if (BigNumber.isBigNumber(amount)) return amount;
-    if (typeof amount === 'string') return token.asUnits(amount);
-    return token.asUnits(amount.toFixed(tokenA.amountOfDecimals));
   }
 
   type SwapInformation = {


### PR DESCRIPTION
We are now making `secondsUntilNextSwap` take any number of pairs, and calculate how many seconds are left until a swap can be executed for any of those pairs