### PR TITLE
feat: remove funds from position

### DIFF
--- a/contracts/DCAHub/DCAHubPositionHandler.sol
+++ b/contracts/DCAHub/DCAHubPositionHandler.sol
@@ -201,7 +201,6 @@ abstract contract DCAHubPositionHandler is ReentrancyGuard, DCAHubConfigHandler,
     uint32 _newAmountOfSwaps,
     bool _increase
   ) internal {
-    if (_amount == 0) revert ZeroAmount();
     _assertPositionExistsAndCanBeOperatedByCaller(_positionId);
 
     DCA memory _userDCA = _userPositions[_positionId];


### PR DESCRIPTION
We are now adding `removeFundsFromPosition`. This method will allow uses to remove un-swapped funds from their position. 

Note: if a user wants to empty their position, they will need to specify the full amount, but amount of swaps can't be 0. This is weird (I agree), but if we allowed amount of swaps to be zero, then it could lead to inconsistencies. For example, if amount of swaps was 0, but amount was half of the unswapped balance, what should happen?

What do you think? Can you think of a better solution?