### PR TITLE
refactor: remove ratios with fee

### DIFF
--- a/contracts/DCAHub/DCAHubParameters.sol
+++ b/contracts/DCAHub/DCAHubParameters.sol
@@ -54,6 +54,8 @@ abstract contract DCAHubParameters is IDCAHubParameters {
   }
 
   function _applyFeeToAmount(uint32 _feeAmount, uint256 _amount) internal pure returns (uint256) {
-    return (_amount * (FEE_PRECISION * 100 - _feeAmount)) / (FEE_PRECISION * 100);
+    // TODO: These 2 are the same, but one might lose precision. Re-check in the futute
+    // return (_amount * (FEE_PRECISION * 100 - _feeAmount)) / (FEE_PRECISION * 100;
+    return (_amount * (FEE_PRECISION - _feeAmount / 100)) / FEE_PRECISION;
   }
 }

--- a/contracts/mocks/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/mocks/DCAHub/DCAHubSwapHandler.sol
@@ -127,19 +127,9 @@ contract DCAHubSwapHandlerMock is DCAHubSwapHandler, DCAHubConfigHandlerMock {
     address _tokenB,
     uint256 _magnitudeA,
     uint256 _magnitudeB,
-    uint32 _swapFee,
     ITimeWeightedOracle _oracle
-  )
-    external
-    view
-    returns (
-      uint256,
-      uint256,
-      uint256,
-      uint256
-    )
-  {
-    return _calculateRatio(_tokenA, _tokenB, _magnitudeA, _magnitudeB, _swapFee, _oracle);
+  ) external view returns (uint256, uint256) {
+    return _calculateRatio(_tokenA, _tokenB, _magnitudeA, _magnitudeB, _oracle);
   }
 
   function _calculateRatio(
@@ -147,26 +137,13 @@ contract DCAHubSwapHandlerMock is DCAHubSwapHandler, DCAHubConfigHandlerMock {
     address _tokenB,
     uint256 _magnitudeA,
     uint256 _magnitudeB,
-    uint32 _swapFee,
     ITimeWeightedOracle _oracle
-  )
-    internal
-    view
-    override
-    returns (
-      uint256 _ratioAToB,
-      uint256 _ratioBToA,
-      uint256 _ratioAToBWithFee,
-      uint256 _ratioBToAWithFee
-    )
-  {
+  ) internal view override returns (uint256 _ratioAToB, uint256 _ratioBToA) {
     _ratioBToA = _ratios[_tokenB][_tokenA];
     if (_ratioBToA == 0) {
-      return super._calculateRatio(_tokenA, _tokenB, _magnitudeA, _magnitudeB, _swapFee, _oracle);
+      return super._calculateRatio(_tokenA, _tokenB, _magnitudeA, _magnitudeB, _oracle);
     }
     _ratioAToB = (_magnitudeA * _magnitudeB) / _ratioBToA;
-    _ratioAToBWithFee = _ratioAToB - _getFeeFromAmount(_swapFee, _ratioAToB);
-    _ratioBToAWithFee = _ratioBToA - _getFeeFromAmount(_swapFee, _ratioBToA);
   }
 
   // Used to register calls

--- a/test/unit/DCAHub/dca-hub-swap-handler.spec.ts
+++ b/test/unit/DCAHub/dca-hub-swap-handler.spec.ts
@@ -307,16 +307,15 @@ contract('DCAHubSwapHandler', () => {
 
   describe('_calculateRatio', () => {
     when('function is called', () => {
-      let ratioAToB: BigNumber, ratioAToBWithFee: BigNumber;
-      let ratioBToA: BigNumber, ratioBToAWithFee: BigNumber;
+      let ratioAToB: BigNumber;
+      let ratioBToA: BigNumber;
       given(async () => {
         await setOracleData({ ratioBToA: tokenA.asUnits(0.6) });
-        [ratioAToB, ratioBToA, ratioAToBWithFee, ratioBToAWithFee] = await DCAHubSwapHandler.calculateRatio(
+        [ratioAToB, ratioBToA] = await DCAHubSwapHandler.calculateRatio(
           tokenA.address,
           tokenB.address,
           tokenA.magnitude,
           tokenB.magnitude,
-          6000,
           timeWeightedOracle.address
         );
       });
@@ -324,10 +323,6 @@ contract('DCAHubSwapHandler', () => {
         const expectedRatioBToA = tokenA.asUnits(0.6);
         expect(ratioAToB).to.equal(tokenA.magnitude.mul(tokenB.magnitude).div(expectedRatioBToA));
         expect(ratioBToA).to.equal(expectedRatioBToA);
-      });
-      then('ratios with fee are also calculated correctly', () => {
-        expect(ratioAToBWithFee).to.equal(APPLY_FEE(ratioAToB));
-        expect(ratioBToAWithFee).to.equal(APPLY_FEE(ratioBToA));
       });
     });
   });


### PR DESCRIPTION
We are now re-calculating the ratios with fees, instead of passing them around. This change makes the code much simpler, and the extra gas-cost is less than 1%