### PR TITLE
feat: add permissions manager

### DIFF
--- a/contracts/DCAPermissionsManager/DCAPermissionsManager.sol
+++ b/contracts/DCAPermissionsManager/DCAPermissionsManager.sol
@@ -1,16 +1,115 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.6;
 
+import '@openzeppelin/contracts/token/ERC721/ERC721.sol';
+import '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
+
+enum Permission {
+  INCREASE,
+  REDUCE,
+  WITHDRAW,
+  TERMINATE
+}
+
+library PermissionMath {
+  function toUInt8(Permission[] memory _permissions) internal pure returns (uint8 _representation) {
+    for (uint256 i; i < _permissions.length; i++) {
+      _representation += uint8(2**uint8(_permissions[i]));
+    }
+  }
+
+  function hasPermission(uint8 _representation, Permission _permission) internal pure returns (bool) {
+    uint256 _bitMask = 2**uint256(_permission);
+    return (_representation & _bitMask) == _bitMask;
+  }
+}
+
 // Note: ideally, this would be part of the DCAHub. However, since we've reached the max bytecode size, we needed to make it its own contract
-contract DCAPermissionsManager {
+contract DCAPermissionsManager is ERC721 {
   error HubAlreadySet();
   error ZeroAddress();
+  error OnlyHubCanExecute();
+  error NotOwner();
+
+  struct PermissionSet {
+    address operator;
+    Permission[] permissions;
+  }
+
+  struct TokenInfo {
+    mapping(address => uint8) permissions;
+    EnumerableSet.AddressSet operators;
+  }
+
+  event Modified(uint256 id, PermissionSet[] permissions);
+
+  using PermissionMath for Permission[];
+  using PermissionMath for uint8;
+  using EnumerableSet for EnumerableSet.AddressSet;
 
   address public hub;
+  mapping(uint256 => TokenInfo) internal _tokens;
+
+  constructor() ERC721('Mean Finance DCA', 'DCA') {}
 
   function setHub(address _hub) external {
     if (_hub == address(0)) revert ZeroAddress();
     if (hub != address(0)) revert HubAlreadySet();
     hub = _hub;
+  }
+
+  function mint(
+    uint256 _id,
+    address _owner,
+    PermissionSet[] calldata _permissions
+  ) external {
+    if (msg.sender != hub) revert OnlyHubCanExecute();
+    _mint(_owner, _id);
+    _setPermissions(_id, _permissions);
+  }
+
+  function hasPermission(
+    uint256 _id,
+    address _address,
+    Permission _permission
+  ) external view returns (bool) {
+    return ownerOf(_id) == _address || _tokens[_id].permissions[_address].hasPermission(_permission);
+  }
+
+  function burn(uint256 _id) external {
+    if (msg.sender != hub) revert OnlyHubCanExecute();
+    _burn(_id);
+  }
+
+  // Note: Callers can clear permissions by sending an empty array
+  function modify(uint256 _id, PermissionSet[] calldata _permissions) external {
+    if (msg.sender != ownerOf(_id)) revert NotOwner();
+    _setPermissions(_id, _permissions);
+    emit Modified(_id, _permissions);
+  }
+
+  function _setPermissions(uint256 _id, PermissionSet[] calldata _permissions) internal {
+    for (uint256 i; i < _permissions.length; i++) {
+      if (_permissions[i].permissions.length == 0) {
+        _tokens[_id].operators.remove(_permissions[i].operator);
+        delete _tokens[_id].permissions[_permissions[i].operator];
+      } else {
+        _tokens[_id].operators.add(_permissions[i].operator);
+        _tokens[_id].permissions[_permissions[i].operator] = _permissions[i].permissions.toUInt8();
+      }
+    }
+  }
+
+  function _beforeTokenTransfer(
+    address,
+    address,
+    uint256 _id
+  ) internal override {
+    TokenInfo storage _info = _tokens[_id];
+    while (_info.operators.length() > 0) {
+      address _operator = _info.operators.at(0);
+      delete _info.permissions[_operator];
+      _info.operators.remove(_operator);
+    }
   }
 }

--- a/contracts/mocks/DCAPermissionsManager/DCAPermissionsManager.sol
+++ b/contracts/mocks/DCAPermissionsManager/DCAPermissionsManager.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity ^0.8.6;
+
+import '../../DCAPermissionsManager/DCAPermissionsManager.sol';
+
+contract DCAPermissionsManagerMock is DCAPermissionsManager {
+  using EnumerableSet for EnumerableSet.AddressSet;
+
+  function operators(uint256 _id) external view returns (address[] memory _operators) {
+    _operators = _tokens[_id].operators.values();
+  }
+}

--- a/js-lib/types.ts
+++ b/js-lib/types.ts
@@ -1,0 +1,6 @@
+export enum Permission {
+  INCREASE,
+  REDUCE,
+  WITHDRAW,
+  TERMINATE,
+}

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "postpublish": "pinst --enable"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "4.3.1",
+    "@openzeppelin/contracts": "4.3.2",
     "@uniswap/v3-periphery": "1.1.1",
     "base64-sol": "1.0.1"
   },

--- a/test/unit/DCAPermissionsManager/dca-permissions-manager.spec.ts
+++ b/test/unit/DCAPermissionsManager/dca-permissions-manager.spec.ts
@@ -1,23 +1,28 @@
 import { expect } from 'chai';
 import { ethers } from 'hardhat';
-import { DCAPermissionsManager__factory, DCAPermissionsManager } from '@typechained';
+import { DCAPermissionsManagerMock__factory, DCAPermissionsManagerMock } from '@typechained';
 import { constants, wallet, behaviours } from '@test-utils';
 import { given, then, when, contract } from '@test-utils/bdd';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signers';
 import { snapshot } from '@test-utils/evm';
+import { Permission } from 'js-lib/types';
+import { TransactionResponse } from '@ethersproject/abstract-provider';
+import { readArgFromEventOrFail } from '@test-utils/event-utils';
+import { Wallet } from '@ethersproject/wallet';
 
 contract('DCAPermissionsManager', () => {
-  let owner: SignerWithAddress;
-  let DCAPermissionsManagerFactory: DCAPermissionsManager__factory;
-  let DCAPermissionsManager: DCAPermissionsManager;
+  let hub: SignerWithAddress;
+  let DCAPermissionsManagerFactory: DCAPermissionsManagerMock__factory;
+  let DCAPermissionsManager: DCAPermissionsManagerMock;
   let snapshotId: string;
 
   before('Setup accounts and contracts', async () => {
-    [owner] = await ethers.getSigners();
+    [hub] = await ethers.getSigners();
     DCAPermissionsManagerFactory = await ethers.getContractFactory(
-      'contracts/DCAPermissionsManager/DCAPermissionsManager.sol:DCAPermissionsManager'
+      'contracts/mocks/DCAPermissionsManager/DCAPermissionsManager.sol:DCAPermissionsManagerMock'
     );
     DCAPermissionsManager = await DCAPermissionsManagerFactory.deploy();
+    await DCAPermissionsManager.setHub(hub.address);
     snapshotId = await snapshot.take();
   });
 
@@ -26,10 +31,22 @@ contract('DCAPermissionsManager', () => {
   });
 
   describe('constructor', () => {
+    let DCAPermissionsManager: DCAPermissionsManagerMock;
+    given(async () => {
+      DCAPermissionsManager = await DCAPermissionsManagerFactory.deploy();
+    });
     when('manager is deployed', () => {
       then('hub is zero address', async () => {
         const hub = await DCAPermissionsManager.hub();
         expect(hub).to.equal(constants.ZERO_ADDRESS);
+      });
+      then('name is correct', async () => {
+        const name = await DCAPermissionsManager.name();
+        expect(name).to.equal('Mean Finance DCA');
+      });
+      then('symbol is correct', async () => {
+        const symbol = await DCAPermissionsManager.symbol();
+        expect(symbol).to.equal('DCA');
       });
     });
   });
@@ -48,7 +65,9 @@ contract('DCAPermissionsManager', () => {
 
     when('parameter is a valid address', () => {
       const ADDRESS = wallet.generateRandomAddress();
+      let DCAPermissionsManager: DCAPermissionsManagerMock;
       given(async () => {
+        DCAPermissionsManager = await DCAPermissionsManagerFactory.deploy();
         await DCAPermissionsManager.setHub(ADDRESS);
       });
       then('hub is set correctly', async () => {
@@ -58,9 +77,6 @@ contract('DCAPermissionsManager', () => {
     });
 
     when('hub is already set', () => {
-      given(async () => {
-        await DCAPermissionsManager.setHub(wallet.generateRandomAddress());
-      });
       then('reverts with message', async () => {
         await behaviours.txShouldRevertWithMessage({
           contract: DCAPermissionsManager,
@@ -70,5 +86,244 @@ contract('DCAPermissionsManager', () => {
         });
       });
     });
+  });
+
+  describe('mint', () => {
+    const TOKEN_ID = 1;
+    when('owner is zero address', () => {
+      then('reverts with message', async () => {
+        await behaviours.txShouldRevertWithMessage({
+          contract: DCAPermissionsManager,
+          func: 'mint',
+          args: [1, constants.ZERO_ADDRESS, []],
+          message: 'ERC721: mint to the zero address',
+        });
+      });
+    });
+    when('id is already in use', () => {
+      given(async () => {
+        await DCAPermissionsManager.mint(TOKEN_ID, constants.NOT_ZERO_ADDRESS, []);
+      });
+      then('reverts with message', async () => {
+        await behaviours.txShouldRevertWithMessage({
+          contract: DCAPermissionsManager,
+          func: 'mint',
+          args: [TOKEN_ID, constants.NOT_ZERO_ADDRESS, []],
+          message: 'ERC721: token already minted',
+        });
+      });
+    });
+    when('caller is not the hub', () => {
+      then('reverts with message', async () => {
+        await behaviours.txShouldRevertWithMessage({
+          contract: DCAPermissionsManager.connect(await wallet.generateRandom()),
+          func: 'mint',
+          args: [TOKEN_ID, constants.NOT_ZERO_ADDRESS, []],
+          message: 'OnlyHubCanExecute',
+        });
+      });
+    });
+    when('mint is executed', () => {
+      const OWNER = wallet.generateRandomAddress();
+      const OPERATOR = constants.NOT_ZERO_ADDRESS;
+      let tx: TransactionResponse;
+
+      given(async () => {
+        tx = await DCAPermissionsManager.mint(TOKEN_ID, OWNER, [{ operator: OPERATOR, permissions: [Permission.WITHDRAW] }]);
+      });
+
+      then('owner has all permisisons', async () => {
+        expect(await DCAPermissionsManager.hasPermission(TOKEN_ID, OWNER, Permission.INCREASE)).to.be.true;
+        expect(await DCAPermissionsManager.hasPermission(TOKEN_ID, OWNER, Permission.REDUCE)).to.be.true;
+        expect(await DCAPermissionsManager.hasPermission(TOKEN_ID, OWNER, Permission.TERMINATE)).to.be.true;
+        expect(await DCAPermissionsManager.hasPermission(TOKEN_ID, OWNER, Permission.WITHDRAW)).to.be.true;
+      });
+
+      then('permissions are assigned properly', async () => {
+        expect(await DCAPermissionsManager.hasPermission(TOKEN_ID, OPERATOR, Permission.WITHDRAW)).to.be.true;
+      });
+
+      then('no extra permissions are assigned', async () => {
+        for (const permission of [Permission.INCREASE, Permission.REDUCE, Permission.TERMINATE]) {
+          expect(await DCAPermissionsManager.hasPermission(TOKEN_ID, OPERATOR, permission)).to.be.false;
+        }
+      });
+
+      then('there operators are assigned', async () => {
+        const operators = await DCAPermissionsManager.operators(TOKEN_ID);
+        expect(operators).to.eql([OPERATOR]);
+      });
+
+      then('nft is created and assigned to owner', async () => {
+        const tokenOwner = await DCAPermissionsManager.ownerOf(TOKEN_ID);
+        const balance = await DCAPermissionsManager.balanceOf(OWNER);
+        expect(tokenOwner).to.equal(OWNER);
+        expect(balance).to.equal(TOKEN_ID);
+      });
+    });
+  });
+  describe('transfer', () => {
+    const TOKEN_ID = 1;
+    const OPERATOR = constants.NOT_ZERO_ADDRESS;
+    const NEW_OWNER = wallet.generateRandomAddress();
+    let owner: Wallet;
+
+    given(async () => {
+      owner = await wallet.generateRandom();
+      await DCAPermissionsManager.mint(TOKEN_ID, owner.address, [{ operator: OPERATOR, permissions: [Permission.WITHDRAW] }]);
+      await DCAPermissionsManager.connect(owner).transferFrom(owner.address, NEW_OWNER, TOKEN_ID);
+    });
+
+    when('a token is transfered', () => {
+      then('reported owner has changed', async () => {
+        const newOwner = await DCAPermissionsManager.ownerOf(TOKEN_ID);
+        expect(newOwner).to.equal(NEW_OWNER);
+      });
+
+      then('previous operators lost permissions', async () => {
+        const hasPermission = await DCAPermissionsManager.hasPermission(TOKEN_ID, OPERATOR, Permission.WITHDRAW);
+        expect(hasPermission).to.be.false;
+      });
+
+      then('operators list is now empty', async () => {
+        const operators = await DCAPermissionsManager.operators(TOKEN_ID);
+        expect(operators).to.be.empty;
+      });
+    });
+  });
+  describe('burn', () => {
+    const TOKEN_ID = 1;
+    const OPERATOR = constants.NOT_ZERO_ADDRESS;
+    const OWNER = wallet.generateRandomAddress();
+
+    given(async () => {
+      await DCAPermissionsManager.mint(TOKEN_ID, OWNER, [{ operator: OPERATOR, permissions: [Permission.WITHDRAW] }]);
+    });
+
+    when('caller is not the hub', () => {
+      then('reverts with message', async () => {
+        await behaviours.txShouldRevertWithMessage({
+          contract: DCAPermissionsManager.connect(await wallet.generateRandom()),
+          func: 'burn',
+          args: [TOKEN_ID],
+          message: 'OnlyHubCanExecute',
+        });
+      });
+    });
+
+    when('the hub is the caller', () => {
+      given(async () => {
+        await DCAPermissionsManager.burn(TOKEN_ID);
+      });
+
+      then('nft is burned', async () => {
+        const balance = await DCAPermissionsManager.balanceOf(OWNER);
+        expect(balance).to.equal(0);
+      });
+
+      then('asking for permission reverts', async () => {
+        await behaviours.txShouldRevertWithMessage({
+          contract: DCAPermissionsManager,
+          func: 'hasPermission',
+          args: [TOKEN_ID, OPERATOR, Permission.WITHDRAW],
+          message: 'ERC721: owner query for nonexistent token',
+        });
+      });
+
+      then('operators list is now empty', async () => {
+        const operators = await DCAPermissionsManager.operators(TOKEN_ID);
+        expect(operators).to.be.empty;
+      });
+    });
+  });
+  describe('modify', () => {
+    const TOKEN_ID = 1;
+    const [OPERATOR_1, OPERATOR_2] = ['0x0000000000000000000000000000000000000001', '0x0000000000000000000000000000000000000002'];
+
+    when('caller is not the owner', () => {
+      given(async () => {
+        const owner = await wallet.generateRandom();
+        await DCAPermissionsManager.mint(TOKEN_ID, owner.address, []);
+      });
+      then('reverts with message', async () => {
+        await behaviours.txShouldRevertWithMessage({
+          contract: DCAPermissionsManager.connect(await wallet.generateRandom()),
+          func: 'modify',
+          args: [TOKEN_ID, []],
+          message: 'NotOwner',
+        });
+      });
+    });
+
+    modifyTest({
+      when: 'permissions are added for a new operators',
+      initial: [{ operator: OPERATOR_1, permissions: [Permission.TERMINATE] }],
+      modify: [{ operator: OPERATOR_2, permissions: [Permission.REDUCE] }],
+      expected: [
+        { operator: OPERATOR_1, permissions: [Permission.TERMINATE] },
+        { operator: OPERATOR_2, permissions: [Permission.REDUCE] },
+      ],
+    });
+
+    modifyTest({
+      when: 'permissions are modified for existing operators',
+      initial: [{ operator: OPERATOR_1, permissions: [Permission.WITHDRAW] }],
+      modify: [
+        { operator: OPERATOR_1, permissions: [Permission.INCREASE] },
+        { operator: OPERATOR_2, permissions: [Permission.REDUCE] },
+      ],
+      expected: [
+        { operator: OPERATOR_1, permissions: [Permission.INCREASE] },
+        { operator: OPERATOR_2, permissions: [Permission.REDUCE] },
+      ],
+    });
+
+    modifyTest({
+      when: 'permissions are removed for existing operators',
+      initial: [{ operator: OPERATOR_1, permissions: [Permission.WITHDRAW] }],
+      modify: [{ operator: OPERATOR_1, permissions: [] }],
+      expected: [{ operator: OPERATOR_1, permissions: [] }],
+    });
+
+    type Permissions = { operator: string; permissions: Permission[] }[];
+    function modifyTest({
+      when: title,
+      initial,
+      modify,
+      expected,
+    }: {
+      when: string;
+      initial: Permissions;
+      modify: Permissions;
+      expected: Permissions;
+    }) {
+      when(title, () => {
+        let tx: TransactionResponse;
+        given(async () => {
+          const owner = await wallet.generateRandom();
+          await DCAPermissionsManager.mint(TOKEN_ID, owner.address, initial);
+          tx = await DCAPermissionsManager.connect(owner).modify(TOKEN_ID, modify);
+        });
+        then('then permissions are updated correctly', async () => {
+          const operators = await DCAPermissionsManager.operators(TOKEN_ID);
+          for (const { operator, permissions } of expected) {
+            for (const permission of [Permission.INCREASE, Permission.REDUCE, Permission.TERMINATE, Permission.WITHDRAW]) {
+              expect(await DCAPermissionsManager.hasPermission(TOKEN_ID, operator, permission)).to.equal(permissions.includes(permission));
+            }
+            expect(operators.includes(operator)).to.equal(permissions.length > 0);
+          }
+        });
+        then('event is emitted', async () => {
+          const id = await readArgFromEventOrFail(tx, 'Modified', 'id');
+          const permissions: any = await readArgFromEventOrFail(tx, 'Modified', 'permissions');
+          expect(id).to.equal(TOKEN_ID);
+          expect(permissions.length).to.equal(modify.length);
+          for (let i = 0; i < modify.length; i++) {
+            expect(permissions[i].operator).to.equal(modify[i].operator);
+            expect(permissions[i].permissions).to.eql(modify[i].permissions);
+          }
+        });
+      });
+    }
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -796,10 +796,10 @@
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.1-solc-0.7-2.tgz#371c67ebffe50f551c3146a9eec5fe6ffe862e92"
   integrity sha512-tAG9LWg8+M2CMu7hIsqHPaTyG4uDzjr6mhvH96LvOpLZZj6tgzTluBt+LsCf1/QaYrlis6pITvpIaIhE+iZB+Q==
 
-"@openzeppelin/contracts@4.3.1":
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.3.1.tgz#c01f791ce6c9d3989ac1a643267501dbe336b9e3"
-  integrity sha512-QjgbPPlmDK2clK1hzjw2ROfY8KA5q+PfhDUUxZFEBCZP9fi6d5FuNoh/Uq0oCTMEKPmue69vhX2jcl0N/tFKGw==
+"@openzeppelin/contracts@4.3.2":
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.3.2.tgz#ff80affd6d352dbe1bbc5b4e1833c41afd6283b6"
+  integrity sha512-AybF1cesONZStg5kWf6ao9OlqTZuPqddvprc0ky7lrUVOjXeKpmQ2Y9FK+6ygxasb+4aic4O5pneFBfwVsRRRg==
 
 "@resolver-engine/core@^0.3.3":
   version "0.3.3"


### PR DESCRIPTION
We are now adding the new `DCAPermissionsManager` contract. This contract will be in charge of handling all permissions + NFT