### PR TITLE
perf: update to solc 0.8.7

### DIFF
--- a/contracts/DCAHub/DCAHub.sol
+++ b/contracts/DCAHub/DCAHub.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import './DCAHubParameters.sol';
 import './DCAHubPositionHandler.sol';

--- a/contracts/DCAHub/DCAHubConfigHandler.sol
+++ b/contracts/DCAHub/DCAHubConfigHandler.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';
 import '@openzeppelin/contracts/access/AccessControl.sol';

--- a/contracts/DCAHub/DCAHubLoanHandler.sol
+++ b/contracts/DCAHub/DCAHubLoanHandler.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
 

--- a/contracts/DCAHub/DCAHubParameters.sol
+++ b/contracts/DCAHub/DCAHubParameters.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';

--- a/contracts/DCAHub/DCAHubPositionHandler.sol
+++ b/contracts/DCAHub/DCAHubPositionHandler.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '@openzeppelin/contracts/token/ERC721/ERC721.sol';
 import '@openzeppelin/contracts/security/ReentrancyGuard.sol';

--- a/contracts/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/DCAHub/DCAHubSwapHandler.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
 

--- a/contracts/DCAHub/utils/Math.sol
+++ b/contracts/DCAHub/utils/Math.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 library Math {
   function tryMul(uint256 a, uint256 b) internal pure returns (bool, uint256) {

--- a/contracts/DCATokenDescriptor/DCATokenDescriptor.sol
+++ b/contracts/DCATokenDescriptor/DCATokenDescriptor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol';
 import '../DCAHub/DCAHub.sol';

--- a/contracts/interfaces/IDCAHub.sol
+++ b/contracts/interfaces/IDCAHub.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol';
 import '@openzeppelin/contracts/token/ERC721/IERC721.sol';

--- a/contracts/interfaces/IDCAHubLoanCallee.sol
+++ b/contracts/interfaces/IDCAHubLoanCallee.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol';
 import './IDCAHub.sol';

--- a/contracts/interfaces/IDCAHubSwapCallee.sol
+++ b/contracts/interfaces/IDCAHubSwapCallee.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol';
 import './IDCAHub.sol';

--- a/contracts/interfaces/IDCATokenDescriptor.sol
+++ b/contracts/interfaces/IDCATokenDescriptor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '../DCAHub/DCAHub.sol';
 

--- a/contracts/libraries/CommonErrors.sol
+++ b/contracts/libraries/CommonErrors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 library CommonErrors {
   error ZeroAddress();

--- a/contracts/libraries/NFTSVG.sol
+++ b/contracts/libraries/NFTSVG.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '@openzeppelin/contracts/utils/Strings.sol';
 

--- a/contracts/mocks/DCAHub/DCAHubConfigHandler.sol
+++ b/contracts/mocks/DCAHub/DCAHubConfigHandler.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '../../DCAHub/DCAHubConfigHandler.sol';
 import './DCAHubParameters.sol';

--- a/contracts/mocks/DCAHub/DCAHubLoanHandler.sol
+++ b/contracts/mocks/DCAHub/DCAHubLoanHandler.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '../../DCAHub/DCAHubLoanHandler.sol';
 import './DCAHubConfigHandler.sol';

--- a/contracts/mocks/DCAHub/DCAHubParameters.sol
+++ b/contracts/mocks/DCAHub/DCAHubParameters.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '../../DCAHub/DCAHubParameters.sol';
 

--- a/contracts/mocks/DCAHub/DCAHubPositionHandler.sol
+++ b/contracts/mocks/DCAHub/DCAHubPositionHandler.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '../../DCAHub/DCAHubPositionHandler.sol';
 import './DCAHubConfigHandler.sol';

--- a/contracts/mocks/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/mocks/DCAHub/DCAHubSwapHandler.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '../../DCAHub/DCAHubSwapHandler.sol';
 import './DCAHubConfigHandler.sol';

--- a/contracts/mocks/DCAHub/TimeWeightedOracleMock.sol
+++ b/contracts/mocks/DCAHub/TimeWeightedOracleMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '../../interfaces/ITimeWeightedOracle.sol';
 

--- a/contracts/mocks/DCAHubLoanCallee.sol
+++ b/contracts/mocks/DCAHubLoanCallee.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '@openzeppelin/contracts/utils/Address.sol';
 

--- a/contracts/mocks/DCAHubSwapCallee.sol
+++ b/contracts/mocks/DCAHubSwapCallee.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '@openzeppelin/contracts/utils/Address.sol';
 

--- a/contracts/mocks/ERC20Mock.sol
+++ b/contracts/mocks/ERC20Mock.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 

--- a/contracts/mocks/ForceETH.sol
+++ b/contracts/mocks/ForceETH.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 contract ForceETH {
   constructor(address payable _to) payable {

--- a/contracts/mocks/NFTDescriptor.sol
+++ b/contracts/mocks/NFTDescriptor.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '../libraries/NFTDescriptor.sol';
 

--- a/contracts/mocks/UniswapV3Oracle/UniswapV3FactoryMock.sol
+++ b/contracts/mocks/UniswapV3Oracle/UniswapV3FactoryMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 contract UniswapV3FactoryMock {
   int24 private _tickSpacing;

--- a/contracts/mocks/UniswapV3Oracle/UniswapV3PoolMock.sol
+++ b/contracts/mocks/UniswapV3Oracle/UniswapV3PoolMock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 contract UniswapV3PoolMock {
   uint16 public cardinalitySent;

--- a/contracts/mocks/utils/CollectableDust.sol
+++ b/contracts/mocks/utils/CollectableDust.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '../../utils/CollectableDust.sol';
 

--- a/contracts/mocks/utils/Governable.sol
+++ b/contracts/mocks/utils/Governable.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: UNLICENSED
 
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '../../utils/Governable.sol';
 

--- a/contracts/utils/CollectableDust.sol
+++ b/contracts/utils/CollectableDust.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-pragma solidity ^0.8.6;
+pragma solidity >=0.8.7 <0.9.0;
 
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 import '@openzeppelin/contracts/utils/structs/EnumerableSet.sol';

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -74,7 +74,7 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: '0.8.6',
+        version: '0.8.7',
         settings: {
           optimizer: {
             enabled: true,


### PR DESCRIPTION
We update our solidity version to be minimum 0.8.7, but max 0.9.x. Honestly, I tagged it as a performance because I thought it would bring some new gas efficencies 😢 