### PR TITLE
feat: add permission permit

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "solidity.compileUsingRemoteVersion": "v0.8.6+commit.11564f7e",
+  "solidity.compileUsingRemoteVersion": "latest",
   "files.exclude": {
     "**/deployments": true
   }

--- a/contracts/mocks/DCAPermissionsManager/DCAPermissionsManager.sol
+++ b/contracts/mocks/DCAPermissionsManager/DCAPermissionsManager.sol
@@ -7,6 +7,8 @@ import '../../DCAPermissionsManager/DCAPermissionsManager.sol';
 contract DCAPermissionsManagerMock is DCAPermissionsManager {
   using EnumerableSet for EnumerableSet.AddressSet;
 
+  constructor(address _governor, IDCATokenDescriptor _descriptor) DCAPermissionsManager(_governor, _descriptor) {}
+
   function operators(uint256 _id) external view returns (address[] memory _operators) {
     _operators = _tokens[_id].operators.values();
   }


### PR DESCRIPTION
We are now adding a new `permissionPermit`. The idea is the same as the one in https://github.com/Mean-Finance/dca-v1.1/pull/67, but instead of executing `approve`, this permit executed `modify`

Note: this method is more complex than the previous one because we need to encode `PermissionSet[]`