### PR TITLE
feat: add governable and nft descriptor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
-  "solidity.compileUsingRemoteVersion": "v0.8.6+commit.11564f7e",
+  "solidity.compileUsingRemoteVersion": "latest",
   "files.exclude": {
     "**/deployments": true
   }

--- a/contracts/mocks/DCAPermissionsManager/DCAPermissionsManager.sol
+++ b/contracts/mocks/DCAPermissionsManager/DCAPermissionsManager.sol
@@ -7,6 +7,8 @@ import '../../DCAPermissionsManager/DCAPermissionsManager.sol';
 contract DCAPermissionsManagerMock is DCAPermissionsManager {
   using EnumerableSet for EnumerableSet.AddressSet;
 
+  constructor(address _governor, IDCATokenDescriptor _descriptor) DCAPermissionsManager(_governor, _descriptor) {}
+
   function operators(uint256 _id) external view returns (address[] memory _operators) {
     _operators = _tokens[_id].operators.values();
   }


### PR DESCRIPTION
We are now making the permissions manager contract implement Governable, so that we can set (and modify) the NFT descriptor

(We will start using the descriptor in another PR)