### PR TITLE
refactor: separate amounts to swap from delta

### DIFF
--- a/contracts/DCAHub/DCAHubParameters.sol
+++ b/contracts/DCAHub/DCAHubParameters.sol
@@ -11,11 +11,21 @@ import '../libraries/CommonErrors.sol';
 import './utils/Math.sol';
 
 abstract contract DCAHubParameters is IDCAHubParameters {
-  struct PairInfo {
+  struct SwapData {
     uint32 performedSwaps;
     uint32 nextSwapAvailable;
     uint256 nextAmountToSwapAToB;
     uint256 nextAmountToSwapBToA;
+  }
+
+  struct SwapDelta {
+    int256 swapDeltaAToB;
+    int256 swapDeltaBToA;
+  }
+
+  struct AccumRatio {
+    uint256 accumRatioAToB;
+    uint256 accumRatioBToA;
   }
 
   using EnumerableSet for EnumerableSet.UintSet;
@@ -24,11 +34,9 @@ abstract contract DCAHubParameters is IDCAHubParameters {
   uint24 public constant FEE_PRECISION = 10000;
 
   // Tracking
-  // TODO: See if there is a way to optimize all these mappings
-  mapping(address => mapping(address => mapping(uint32 => mapping(uint32 => int256)))) public swapAmountDelta; // from token => to token => swap interval => swap number => delta
-  mapping(address => mapping(address => mapping(uint32 => mapping(uint32 => uint256)))) public accumRatio; // from token => to token => swap interval => swap number => accum
-
-  mapping(address => mapping(address => mapping(uint32 => PairInfo))) public pairInfo; // token A => token B => swap interval => token info
+  mapping(address => mapping(address => mapping(uint32 => mapping(uint32 => SwapDelta)))) public swapAmountDelta; // token A => token B => swap interval => swap number => delta
+  mapping(address => mapping(address => mapping(uint32 => mapping(uint32 => AccumRatio)))) public accumRatio; // token A => token B => swap interval => swap number => accum
+  mapping(address => mapping(address => mapping(uint32 => SwapData))) public swapData; // token A => token B => swap interval => swap data
   mapping(address => mapping(address => EnumerableSet.UintSet)) internal _activeSwapIntervals; // token A => token B => active swap intervals
 
   mapping(address => uint256) public platformBalance; // token => balance

--- a/contracts/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/DCAHub/DCAHubSwapHandler.sol
@@ -20,25 +20,25 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
     uint256 _ratioBToA,
     uint32 _timestamp
   ) internal virtual {
-    PairInfo memory _pairInfo = pairInfo[_tokenA][_tokenB][_swapInterval];
-    if (_pairInfo.nextAmountToSwapAToB > 0 || _pairInfo.nextAmountToSwapBToA > 0) {
-      uint32 _swapToRegister = _pairInfo.performedSwaps + 1;
-      accumRatio[_tokenA][_tokenB][_swapInterval][_swapToRegister] =
-        accumRatio[_tokenA][_tokenB][_swapInterval][_swapToRegister - 1] +
-        _ratioAToB;
-      accumRatio[_tokenB][_tokenA][_swapInterval][_swapToRegister] =
-        accumRatio[_tokenB][_tokenA][_swapInterval][_swapToRegister - 1] +
-        _ratioBToA;
-      unchecked {
-        pairInfo[_tokenA][_tokenB][_swapInterval] = PairInfo({
-          performedSwaps: _swapToRegister,
-          nextSwapAvailable: ((_timestamp / _swapInterval) + 1) * _swapInterval,
-          nextAmountToSwapAToB: _pairInfo.nextAmountToSwapAToB + uint256(swapAmountDelta[_tokenA][_tokenB][_swapInterval][_swapToRegister + 1]),
-          nextAmountToSwapBToA: _pairInfo.nextAmountToSwapBToA + uint256(swapAmountDelta[_tokenB][_tokenA][_swapInterval][_swapToRegister + 1])
-        });
-      }
-      delete swapAmountDelta[_tokenA][_tokenB][_swapInterval][_swapToRegister + 1];
-      delete swapAmountDelta[_tokenB][_tokenA][_swapInterval][_swapToRegister + 1];
+    SwapData memory _swapData = swapData[_tokenA][_tokenB][_swapInterval];
+    if (_swapData.nextAmountToSwapAToB > 0 || _swapData.nextAmountToSwapBToA > 0) {
+      AccumRatio memory _accumRatio = accumRatio[_tokenA][_tokenB][_swapInterval][_swapData.performedSwaps];
+      SwapDelta memory _swapDelta = swapAmountDelta[_tokenA][_tokenB][_swapInterval][_swapData.performedSwaps + 2];
+      accumRatio[_tokenA][_tokenB][_swapInterval][_swapData.performedSwaps + 1] = AccumRatio({
+        accumRatioAToB: _accumRatio.accumRatioAToB + _ratioAToB,
+        accumRatioBToA: _accumRatio.accumRatioBToA + _ratioBToA
+      });
+      swapData[_tokenA][_tokenB][_swapInterval] = SwapData({
+        performedSwaps: _swapData.performedSwaps + 1,
+        nextSwapAvailable: ((_timestamp / _swapInterval) + 1) * _swapInterval,
+        nextAmountToSwapAToB: _swapDelta.swapDeltaAToB < 0
+          ? _swapData.nextAmountToSwapAToB - uint256(-_swapDelta.swapDeltaAToB)
+          : _swapData.nextAmountToSwapAToB + uint256(_swapDelta.swapDeltaAToB),
+        nextAmountToSwapBToA: _swapDelta.swapDeltaBToA < 0
+          ? _swapData.nextAmountToSwapBToA - uint256(-_swapDelta.swapDeltaBToA)
+          : _swapData.nextAmountToSwapBToA + uint256(_swapDelta.swapDeltaBToA)
+      });
+      delete swapAmountDelta[_tokenA][_tokenB][_swapInterval][_swapData.performedSwaps + 2];
     } else {
       _activeSwapIntervals[_tokenA][_tokenB].remove(_swapInterval);
     }
@@ -76,7 +76,7 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
     _secondsUntil = type(uint32).max;
     for (uint256 i; i < _activeSwapIntervals[_tokenA][_tokenB].length(); i++) {
       uint32 _swapInterval = uint32(_activeSwapIntervals[_tokenA][_tokenB].at(i));
-      uint32 _nextAvailable = pairInfo[_tokenA][_tokenB][_swapInterval].nextSwapAvailable;
+      uint32 _nextAvailable = swapData[_tokenA][_tokenB][_swapInterval].nextSwapAvailable;
       if (_nextAvailable <= _timestamp) {
         return 0;
       } else {
@@ -108,11 +108,11 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
     uint32 _blockTimestamp = _getTimestamp();
     for (uint256 i; i < _intervalsInSwap.length; i++) {
       uint32 _swapInterval = uint32(_swapIntervals.at(i));
-      PairInfo memory _pairInfo = pairInfo[_tokenA][_tokenB][_swapInterval];
-      if (_pairInfo.nextSwapAvailable <= _blockTimestamp) {
+      SwapData memory _swapData = swapData[_tokenA][_tokenB][_swapInterval];
+      if (_swapData.nextSwapAvailable <= _blockTimestamp) {
         _intervalsInSwap[_intervalCount++] = _swapInterval;
-        _totalAmountToSwapTokenA += _pairInfo.nextAmountToSwapAToB;
-        _totalAmountToSwapTokenB += _pairInfo.nextAmountToSwapBToA;
+        _totalAmountToSwapTokenA += _swapData.nextAmountToSwapAToB;
+        _totalAmountToSwapTokenB += _swapData.nextAmountToSwapBToA;
       }
     }
 

--- a/contracts/mocks/DCAHub/DCAHubParameters.sol
+++ b/contracts/mocks/DCAHub/DCAHubParameters.sol
@@ -37,23 +37,25 @@ contract DCAHubParametersMock is DCAHubParameters {
   }
 
   function setSwapAmountDelta(
-    address _from,
-    address _to,
+    address _tokenA,
+    address _tokenB,
     uint32 _swapInterval,
     uint32 _swap,
-    int256 _value
+    int128 _deltaAToB,
+    int128 _deltaBToA
   ) external {
-    swapAmountDelta[_from][_to][_swapInterval][_swap] = _value;
+    swapAmountDelta[_tokenA][_tokenB][_swapInterval][_swap] = SwapDelta(_deltaAToB, _deltaBToA);
   }
 
   function setAcummRatio(
-    address _from,
-    address _to,
+    address _tokenA,
+    address _tokenB,
     uint32 _swapInterval,
     uint32 _swap,
-    uint256 _accumRatio
+    uint256 _accumRatioAToB,
+    uint256 _accumRatioBToA
   ) external {
-    accumRatio[_from][_to][_swapInterval][_swap] = _accumRatio;
+    accumRatio[_tokenA][_tokenB][_swapInterval][_swap] = AccumRatio(_accumRatioAToB, _accumRatioBToA);
   }
 
   function setNextAmountsToSwap(
@@ -63,8 +65,8 @@ contract DCAHubParametersMock is DCAHubParameters {
     uint256 _amountToSwapAToB,
     uint256 _amountToSwapBToA
   ) external {
-    pairInfo[_tokenA][_tokenB][_swapInterval].nextAmountToSwapAToB = _amountToSwapAToB;
-    pairInfo[_tokenA][_tokenB][_swapInterval].nextAmountToSwapBToA = _amountToSwapBToA;
+    swapData[_tokenA][_tokenB][_swapInterval].nextAmountToSwapAToB = _amountToSwapAToB;
+    swapData[_tokenA][_tokenB][_swapInterval].nextAmountToSwapBToA = _amountToSwapBToA;
   }
 
   function setPerformedSwaps(
@@ -73,7 +75,7 @@ contract DCAHubParametersMock is DCAHubParameters {
     uint32 _swapInterval,
     uint32 _performedSwaps
   ) external {
-    pairInfo[_tokenA][_tokenB][_swapInterval].performedSwaps = _performedSwaps;
+    swapData[_tokenA][_tokenB][_swapInterval].performedSwaps = _performedSwaps;
   }
 
   function getFeeFromAmount(uint32 _feeAmount, uint256 _amount) external pure returns (uint256) {

--- a/contracts/mocks/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/mocks/DCAHub/DCAHubSwapHandler.sol
@@ -171,6 +171,6 @@ contract DCAHubSwapHandlerMock is DCAHubSwapHandler, DCAHubConfigHandlerMock {
     uint32 _swapInterval,
     uint32 _nextSwapAvailable
   ) external {
-    pairInfo[_tokenA][_tokenB][_swapInterval].nextSwapAvailable = _nextSwapAvailable;
+    swapData[_tokenA][_tokenB][_swapInterval].nextSwapAvailable = _nextSwapAvailable;
   }
 }

--- a/test/e2e/DCAHub/happy-path.spec.ts
+++ b/test/e2e/DCAHub/happy-path.spec.ts
@@ -453,7 +453,7 @@ contract('DCAHub', () => {
       let totalTokenB = constants.ZERO;
 
       for (const interval of intervalsInSwap) {
-        const { nextAmountToSwapAToB, nextAmountToSwapBToA } = await DCAHub.pairInfo(tokenA.address, tokenB.address, interval);
+        const { nextAmountToSwapAToB, nextAmountToSwapBToA } = await DCAHub.swapData(tokenA.address, tokenB.address, interval);
         totalTokenA = totalTokenA.add(nextAmountToSwapAToB);
         totalTokenB = totalTokenB.add(nextAmountToSwapBToA);
       }

--- a/test/unit/DCAHub/dca-hub-swap-handler.spec.ts
+++ b/test/unit/DCAHub/dca-hub-swap-handler.spec.ts
@@ -104,14 +104,17 @@ contract('DCAHubSwapHandler', () => {
         expect(await DCAHubSwapHandler.isSwapIntervalActive(tokenA.address, tokenB.address, SWAP_INTERVAL)).to.be.false;
       });
       then('next delta is not modified', async () => {
-        const deltaInNextSwapAToB = await DCAHubSwapHandler.swapAmountDelta(tokenA.address, tokenB.address, SWAP_INTERVAL, NEXT_SWAP + 1);
-        const deltaInNextSwapBToA = await DCAHubSwapHandler.swapAmountDelta(tokenB.address, tokenA.address, SWAP_INTERVAL, NEXT_SWAP + 1);
-        expect(deltaInNextSwapAToB).to.equal(0);
-        expect(deltaInNextSwapBToA).to.equal(0);
+        const { swapDeltaAToB, swapDeltaBToA } = await DCAHubSwapHandler.swapAmountDelta(
+          tokenA.address,
+          tokenB.address,
+          SWAP_INTERVAL,
+          NEXT_SWAP + 1
+        );
+        expect(swapDeltaAToB).to.equal(0);
+        expect(swapDeltaBToA).to.equal(0);
       });
       then('rate per unit is not increased', async () => {
-        const accumRatioAToB = await DCAHubSwapHandler.accumRatio(tokenA.address, tokenB.address, SWAP_INTERVAL, NEXT_SWAP);
-        const accumRatioBToA = await DCAHubSwapHandler.accumRatio(tokenB.address, tokenA.address, SWAP_INTERVAL, NEXT_SWAP);
+        const { accumRatioAToB, accumRatioBToA } = await DCAHubSwapHandler.accumRatio(tokenA.address, tokenB.address, SWAP_INTERVAL, NEXT_SWAP);
         expect(accumRatioAToB).to.equal(0);
         expect(accumRatioBToA).to.equal(0);
       });
@@ -124,12 +127,12 @@ contract('DCAHubSwapHandler', () => {
     });
 
     async function getPerformedSwaps(tokenA: TokenContract, tokenB: TokenContract, swapInterval: number) {
-      const { performedSwaps } = await DCAHubSwapHandler.pairInfo(tokenA.address, tokenB.address, swapInterval);
+      const { performedSwaps } = await DCAHubSwapHandler.swapData(tokenA.address, tokenB.address, swapInterval);
       return performedSwaps;
     }
 
     async function nextSwapAvailable(tokenA: TokenContract, tokenB: TokenContract, swapInterval: number) {
-      const { nextSwapAvailable } = await DCAHubSwapHandler.pairInfo(tokenA.address, tokenB.address, swapInterval);
+      const { nextSwapAvailable } = await DCAHubSwapHandler.swapData(tokenA.address, tokenB.address, swapInterval);
       return nextSwapAvailable;
     }
 
@@ -176,13 +179,7 @@ contract('DCAHubSwapHandler', () => {
             tokenB().address,
             SWAP_INTERVAL,
             nextSwapNumber + 1,
-            NEXT_DELTA_FROM_A_TO_B
-          );
-          await DCAHubSwapHandler.setSwapAmountDelta(
-            tokenB().address,
-            tokenA().address,
-            SWAP_INTERVAL,
-            nextSwapNumber + 1,
+            NEXT_DELTA_FROM_A_TO_B,
             NEXT_DELTA_FROM_B_TO_A
           );
           await DCAHubSwapHandler.setPerformedSwaps(tokenA().address, tokenB().address, SWAP_INTERVAL, nextSwapNumber - 1);
@@ -193,13 +190,7 @@ contract('DCAHubSwapHandler', () => {
               tokenB().address,
               SWAP_INTERVAL,
               nextSwapNumber - 1,
-              previous.accumRatioAToB
-            );
-            await DCAHubSwapHandler.setAcummRatio(
-              tokenB().address,
-              tokenA().address,
-              SWAP_INTERVAL,
-              nextSwapNumber - 1,
+              previous.accumRatioAToB,
               previous.accumRatioBToA
             );
           }
@@ -207,32 +198,34 @@ contract('DCAHubSwapHandler', () => {
           await DCAHubSwapHandler.registerSwap(tokenA().address, tokenB().address, SWAP_INTERVAL, ratioAToB, ratioBToA, blockTimestamp);
         });
 
-        describe('token A to B', () => {
-          then('adds the current delta to the next amount to swap', async () => {
-            const { nextAmountToSwapAToB } = await DCAHubSwapHandler.pairInfo(tokenA().address, tokenB().address, SWAP_INTERVAL);
-            expect(nextAmountToSwapAToB).to.equal(bn.toBN(amountToSwapTokenA).add(NEXT_DELTA_FROM_A_TO_B));
-          });
-          then('increments the rate per unit accumulator', async () => {
-            const accumRatios = await DCAHubSwapHandler.accumRatio(tokenA().address, tokenB().address, SWAP_INTERVAL, nextSwapNumber);
-            expect(accumRatios).to.equal(bn.toBN(ratioAToB).add(previous?.accumRatioAToB ?? 0));
-          });
-          then('deletes swap amount delta of the following swap', async () => {
-            expect(await DCAHubSwapHandler.swapAmountDelta(tokenA().address, tokenB().address, SWAP_INTERVAL, nextSwapNumber + 1)).to.equal(0);
-          });
+        then('adds the current delta to the next amount to swap', async () => {
+          const { nextAmountToSwapAToB, nextAmountToSwapBToA } = await DCAHubSwapHandler.swapData(
+            tokenA().address,
+            tokenB().address,
+            SWAP_INTERVAL
+          );
+          expect(nextAmountToSwapAToB).to.equal(bn.toBN(amountToSwapTokenA).add(NEXT_DELTA_FROM_A_TO_B));
+          expect(nextAmountToSwapBToA).to.equal(bn.toBN(amountToSwapTokenB).add(NEXT_DELTA_FROM_B_TO_A));
         });
-
-        describe('token B to A', () => {
-          then('adds the current delta to the next amount to swap', async () => {
-            const { nextAmountToSwapBToA } = await DCAHubSwapHandler.pairInfo(tokenA().address, tokenB().address, SWAP_INTERVAL);
-            expect(nextAmountToSwapBToA).to.equal(bn.toBN(amountToSwapTokenB).add(NEXT_DELTA_FROM_B_TO_A));
-          });
-          then('increments the rate per unit accumulator', async () => {
-            const accumRatios = await DCAHubSwapHandler.accumRatio(tokenB().address, tokenA().address, SWAP_INTERVAL, nextSwapNumber);
-            expect(accumRatios).to.equal(bn.toBN(ratioBToA).add(previous?.accumRatioBToA ?? 0));
-          });
-          then('deletes swap amount delta of the following swap', async () => {
-            expect(await DCAHubSwapHandler.swapAmountDelta(tokenB().address, tokenA().address, SWAP_INTERVAL, nextSwapNumber + 1)).to.equal(0);
-          });
+        then('increments the rate per unit accumulator', async () => {
+          const { accumRatioAToB, accumRatioBToA } = await DCAHubSwapHandler.accumRatio(
+            tokenA().address,
+            tokenB().address,
+            SWAP_INTERVAL,
+            nextSwapNumber
+          );
+          expect(accumRatioAToB).to.equal(bn.toBN(ratioAToB).add(previous?.accumRatioAToB ?? 0));
+          expect(accumRatioBToA).to.equal(bn.toBN(ratioBToA).add(previous?.accumRatioBToA ?? 0));
+        });
+        then('deletes swap amount delta of the following swap', async () => {
+          const { swapDeltaAToB, swapDeltaBToA } = await DCAHubSwapHandler.swapAmountDelta(
+            tokenA().address,
+            tokenB().address,
+            SWAP_INTERVAL,
+            nextSwapNumber + 1
+          );
+          expect(swapDeltaAToB).to.equal(0);
+          expect(swapDeltaBToA).to.equal(0);
         });
 
         then('performed swaps is incremented', async () => {


### PR DESCRIPTION
We are now adding two new variables to the `PairInfo` struct: `nextAmountToSwapAToB` and `nextAmountToSwapBToA`.
The idea is for us to store the amount to swap on the next swap in this struct, instead of using the first position in delta. 

We are doing this because we often read and write all values in `PairInfo` together, so we can save up a lot of gas this way