### PR TITLE
perf: reduce int size

### DIFF
--- a/contracts/DCAHub/DCAHubParameters.sol
+++ b/contracts/DCAHub/DCAHubParameters.sol
@@ -12,14 +12,14 @@ import './utils/Math.sol';
 abstract contract DCAHubParameters is IDCAHubParameters {
   struct SwapData {
     uint32 performedSwaps;
+    uint224 nextAmountToSwapAToB;
     uint32 nextSwapAvailable;
-    uint256 nextAmountToSwapAToB;
-    uint256 nextAmountToSwapBToA;
+    uint224 nextAmountToSwapBToA;
   }
 
   struct SwapDelta {
-    int256 swapDeltaAToB;
-    int256 swapDeltaBToA;
+    int128 swapDeltaAToB;
+    int128 swapDeltaBToA;
   }
 
   struct AccumRatio {

--- a/contracts/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/DCAHub/DCAHubSwapHandler.sol
@@ -32,11 +32,11 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
         performedSwaps: _swapData.performedSwaps + 1,
         nextSwapAvailable: ((_timestamp / _swapInterval) + 1) * _swapInterval,
         nextAmountToSwapAToB: _swapDelta.swapDeltaAToB < 0
-          ? _swapData.nextAmountToSwapAToB - uint256(-_swapDelta.swapDeltaAToB)
-          : _swapData.nextAmountToSwapAToB + uint256(_swapDelta.swapDeltaAToB),
+          ? _swapData.nextAmountToSwapAToB - uint128(-_swapDelta.swapDeltaAToB)
+          : _swapData.nextAmountToSwapAToB + uint128(_swapDelta.swapDeltaAToB),
         nextAmountToSwapBToA: _swapDelta.swapDeltaBToA < 0
-          ? _swapData.nextAmountToSwapBToA - uint256(-_swapDelta.swapDeltaBToA)
-          : _swapData.nextAmountToSwapBToA + uint256(_swapDelta.swapDeltaBToA)
+          ? _swapData.nextAmountToSwapBToA - uint128(-_swapDelta.swapDeltaBToA)
+          : _swapData.nextAmountToSwapBToA + uint128(_swapDelta.swapDeltaBToA)
       });
       delete swapAmountDelta[_tokenA][_tokenB][_swapIntervalMask][_swapData.performedSwaps + 2];
     } else {

--- a/contracts/mocks/DCAHub/DCAHubParameters.sol
+++ b/contracts/mocks/DCAHub/DCAHubParameters.sol
@@ -60,8 +60,8 @@ contract DCAHubParametersMock is DCAHubParameters {
     address _tokenA,
     address _tokenB,
     uint32 _swapInterval,
-    uint256 _amountToSwapAToB,
-    uint256 _amountToSwapBToA
+    uint224 _amountToSwapAToB,
+    uint224 _amountToSwapBToA
   ) external {
     swapData[_tokenA][_tokenB][intervalToMask(_swapInterval)].nextAmountToSwapAToB = _amountToSwapAToB;
     swapData[_tokenA][_tokenB][intervalToMask(_swapInterval)].nextAmountToSwapBToA = _amountToSwapBToA;


### PR DESCRIPTION
We are simply reducing the int size of some variables, so that we can reduce the gas cost of storing them