### PR TITLE
refactor: make fees multiple of 100

### DIFF
--- a/contracts/DCAHub/DCAHubConfigHandler.sol
+++ b/contracts/DCAHub/DCAHubConfigHandler.sol
@@ -21,6 +21,7 @@ abstract contract DCAHubConfigHandler is DCAHubParameters, AccessControl, Pausab
   error InvalidParams();
   error ZeroInterval();
   error EmptyDescription();
+  error InvalidFee();
 
   bytes32 public constant IMMEDIATE_ROLE = keccak256('IMMEDIATE_ROLE');
   bytes32 public constant TIME_LOCKED_ROLE = keccak256('TIME_LOCKED_ROLE');
@@ -55,12 +56,14 @@ abstract contract DCAHubConfigHandler is DCAHubParameters, AccessControl, Pausab
 
   function setSwapFee(uint32 _swapFee) external onlyRole(TIME_LOCKED_ROLE) {
     if (_swapFee > MAX_FEE) revert HighFee();
+    if (_swapFee % 100 != 0) revert InvalidFee();
     swapFee = _swapFee;
     emit SwapFeeSet(_swapFee);
   }
 
   function setLoanFee(uint32 _loanFee) external onlyRole(TIME_LOCKED_ROLE) {
     if (_loanFee > MAX_FEE) revert HighFee();
+    if (_loanFee % 100 != 0) revert InvalidFee();
     loanFee = _loanFee;
     emit LoanFeeSet(_loanFee);
   }

--- a/contracts/DCAHub/DCAHubParameters.sol
+++ b/contracts/DCAHub/DCAHubParameters.sol
@@ -57,8 +57,6 @@ abstract contract DCAHubParameters is IDCAHubParameters {
   }
 
   function _applyFeeToAmount(uint32 _feeAmount, uint256 _amount) internal pure returns (uint256) {
-    // TODO: These 2 are the same, but one might lose precision. Re-check in the futute
-    // return (_amount * (FEE_PRECISION * 100 - _feeAmount)) / (FEE_PRECISION * 100;
     return (_amount * (FEE_PRECISION - _feeAmount / 100)) / FEE_PRECISION;
   }
 }

--- a/test/unit/DCAHub/dca-hub-config-handler.spec.ts
+++ b/test/unit/DCAHub/dca-hub-config-handler.spec.ts
@@ -120,6 +120,16 @@ contract('DCAHubConfigHandler', () => {
         });
       });
     });
+    when('sets fee that is not multiple of 100', () => {
+      then('tx is reverted with reason', async () => {
+        await behaviours.txShouldRevertWithMessage({
+          contract: DCAHubConfigHandler.connect(timeLockedOwner),
+          func: 'setSwapFee',
+          args: [99],
+          message: 'InvalidFee',
+        });
+      });
+    });
     when('sets fee equal to MAX_FEE', () => {
       then('sets fee and emits event', async () => {
         await behaviours.txShouldSetVariableAndEmitEvent({
@@ -137,7 +147,7 @@ contract('DCAHubConfigHandler', () => {
           contract: DCAHubConfigHandler.connect(timeLockedOwner),
           getterFunc: 'swapFee',
           setterFunc: 'setSwapFee',
-          variable: (await DCAHubConfigHandler.MAX_FEE()) - 1,
+          variable: (await DCAHubConfigHandler.MAX_FEE()) - 100,
           eventEmitted: 'SwapFeeSet',
         });
       });
@@ -162,6 +172,16 @@ contract('DCAHubConfigHandler', () => {
         });
       });
     });
+    when('sets fee that is not multiple of 100', () => {
+      then('tx is reverted with reason', async () => {
+        await behaviours.txShouldRevertWithMessage({
+          contract: DCAHubConfigHandler.connect(timeLockedOwner),
+          func: 'setLoanFee',
+          args: [99],
+          message: 'InvalidFee',
+        });
+      });
+    });
     when('sets fee equal to MAX_FEE', () => {
       then('sets fee and emits event', async () => {
         await behaviours.txShouldSetVariableAndEmitEvent({
@@ -179,7 +199,7 @@ contract('DCAHubConfigHandler', () => {
           contract: DCAHubConfigHandler.connect(timeLockedOwner),
           getterFunc: 'loanFee',
           setterFunc: 'setLoanFee',
-          variable: (await DCAHubConfigHandler.MAX_FEE()) - 1,
+          variable: (await DCAHubConfigHandler.MAX_FEE()) - 100,
           eventEmitted: 'LoanFeeSet',
         });
       });


### PR DESCRIPTION
We are now forcing fees to be multiple of 100, so we can take advantage of a small optimization that saves us 1k gas on swaps, without having to worry about precision 