### PR TITLE
refactor: avoid swaps for state cleaning

### DIFF
--- a/contracts/mocks/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/mocks/DCAHub/DCAHubSwapHandler.sol
@@ -81,15 +81,11 @@ contract DCAHubSwapHandlerMock is DCAHubSwapHandler, DCAHubConfigHandlerMock {
     _affectedIntervals = _amounts.intervalsInSwap;
   }
 
-  function internalGetNextSwapInfo(address[] calldata _tokens, PairIndexes[] calldata _pairs) external view returns (SwapInfo memory) {
-    return _getNextSwapInfo(_tokens, _pairs);
-  }
-
-  function _getNextSwapInfo(address[] calldata _tokens, PairIndexes[] calldata _pairs) internal view override returns (SwapInfo memory) {
+  function getNextSwapInfo(address[] calldata _tokens, PairIndexes[] calldata _pairs) public view override returns (SwapInfo memory) {
     if (_swapInformation.tokens.length > 0) {
       return _swapInformation;
     } else {
-      return super._getNextSwapInfo(_tokens, _pairs);
+      return super.getNextSwapInfo(_tokens, _pairs);
     }
   }
 

--- a/js-lib/interval-utils.ts
+++ b/js-lib/interval-utils.ts
@@ -1,0 +1,43 @@
+export class SwapInterval {
+  static readonly FIVE_MINUTES = new SwapInterval(5 * 60, '0x01');
+  static readonly FIFTEEN_MINUTES = new SwapInterval(SwapInterval.FIVE_MINUTES.seconds * 3, '0x02');
+  static readonly THIRTY_MINUTES = new SwapInterval(SwapInterval.FIFTEEN_MINUTES.seconds * 2, '0x4');
+  static readonly ONE_HOUR = new SwapInterval(SwapInterval.THIRTY_MINUTES.seconds * 2, '0x08');
+  static readonly TWELVE_HOURS = new SwapInterval(SwapInterval.ONE_HOUR.seconds * 12, '0x10');
+  static readonly ONE_DAY = new SwapInterval(SwapInterval.TWELVE_HOURS.seconds * 2, '0x20');
+  static readonly ONE_WEEK = new SwapInterval(SwapInterval.ONE_DAY.seconds * 7, '0x40');
+  static readonly THIRTY_DAYS = new SwapInterval(SwapInterval.ONE_DAY.seconds * 30, '0x80');
+
+  private static readonly INTERVALS = [
+    SwapInterval.FIVE_MINUTES,
+    SwapInterval.FIFTEEN_MINUTES,
+    SwapInterval.THIRTY_MINUTES,
+    SwapInterval.ONE_HOUR,
+    SwapInterval.TWELVE_HOURS,
+    SwapInterval.ONE_DAY,
+    SwapInterval.ONE_WEEK,
+    SwapInterval.THIRTY_DAYS,
+  ];
+
+  private constructor(readonly seconds: number, readonly mask: string) {}
+
+  static intervalsToByte(...intervals: SwapInterval[]): string {
+    const finalMask = intervals.map((intervals) => parseInt(intervals.mask)).reduce((a, b) => a | b, 0);
+    return '0x' + finalMask.toString(16).padStart(2, '0');
+  }
+
+  static intervalsfromByte(byte: string): SwapInterval[] {
+    let num = parseInt(byte);
+    let index = 0;
+    const result = [];
+    while (index <= 8 && 1 << index <= num) {
+      if ((num & (1 << index)) != 0) {
+        result.push(SwapInterval.INTERVALS[index]);
+      }
+      index++;
+    }
+    return result;
+  }
+}
+
+// TODO: Add tests for this file

--- a/test/e2e/DCAHub/happy-path.spec.ts
+++ b/test/e2e/DCAHub/happy-path.spec.ts
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import { expect } from 'chai';
 import { BigNumber } from 'ethers';
 import { ethers } from 'hardhat';
@@ -21,11 +20,10 @@ import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/dist/src/signers';
 import { TokenContract } from '@test-utils/erc20';
 import { readArgFromEventOrFail } from '@test-utils/event-utils';
 import { buildGetNextSwapInfoInput, buildSwapInput } from 'js-lib/swap-utils';
+import { SwapInterval } from 'js-lib/interval-utils';
 
 contract('DCAHub', () => {
   describe('Full e2e test', () => {
-    const SWAP_INTERVAL_15_MINUTES = moment.duration(15, 'minutes').as('seconds');
-    const SWAP_INTERVAL_1_HOUR = moment.duration(1, 'hour').as('seconds');
     const MAX_UINT_32 = BigNumber.from(2).pow(32).sub(1);
 
     let governor: SignerWithAddress, john: SignerWithAddress;
@@ -70,7 +68,7 @@ contract('DCAHub', () => {
       await setSwapRatio(swapRatio1);
       DCAHub = await DCAHubFactory.deploy(governor.address, governor.address, timeWeightedOracle.address, DCAPermissionsManager.address);
       await DCAPermissionsManager.setHub(DCAHub.address);
-      await DCAHub.addSwapIntervalsToAllowedList([SWAP_INTERVAL_15_MINUTES, SWAP_INTERVAL_1_HOUR]);
+      await DCAHub.addSwapIntervalsToAllowedList([SwapInterval.FIFTEEN_MINUTES.seconds, SwapInterval.ONE_HOUR.seconds]);
       DCAHubSwapCallee = await DCAHubSwapCalleeFactory.deploy();
       await DCAHubSwapCallee.setInitialBalances([tokenA.address, tokenB.address], [tokenA.asUnits(2500), tokenB.asUnits(2500)]);
 
@@ -83,18 +81,18 @@ contract('DCAHub', () => {
     });
 
     it('Execute happy path', async () => {
-      await assertThereAreNoSwapsAvailable();
+      await assertNoSwapsCanBeExecutedNow();
 
       const johnsPosition = await deposit({
         depositor: john,
         token: tokenA,
-        swapInterval: SWAP_INTERVAL_15_MINUTES,
+        swapInterval: SwapInterval.FIFTEEN_MINUTES,
         rate: 100,
         swaps: 10,
       });
 
       await assertPositionIsConsistent(johnsPosition);
-      await assertIntervalsToSwapNowAre(SWAP_INTERVAL_15_MINUTES);
+      await assertIntervalsToSwapNowAre(SwapInterval.FIFTEEN_MINUTES);
       await assertHubBalanceDifferencesAre({ tokenA: +1000 });
       await assertAmountsToSwapAre({ tokenA: 100, tokenB: 0 });
 
@@ -109,19 +107,19 @@ contract('DCAHub', () => {
       const lucysPosition = await deposit({
         depositor: lucy,
         token: tokenB,
-        swapInterval: SWAP_INTERVAL_1_HOUR,
+        swapInterval: SwapInterval.ONE_HOUR,
         rate: 200,
         swaps: 2,
       });
 
       await assertPositionIsConsistent(lucysPosition);
-      await assertIntervalsToSwapNowAre(SWAP_INTERVAL_1_HOUR);
+      await assertIntervalsToSwapNowAre(SwapInterval.ONE_HOUR);
       await assertAmountsToSwapAre({ tokenA: 0, tokenB: 200 });
       await assertHubBalanceDifferencesAre({ tokenB: +400 });
 
-      await evm.advanceTimeAndBlock(SWAP_INTERVAL_15_MINUTES);
+      await evm.advanceTimeAndBlock(SwapInterval.FIFTEEN_MINUTES.seconds);
 
-      await assertIntervalsToSwapNowAre(SWAP_INTERVAL_15_MINUTES, SWAP_INTERVAL_1_HOUR);
+      await assertIntervalsToSwapNowAre(SwapInterval.FIFTEEN_MINUTES, SwapInterval.ONE_HOUR);
       await assertAmountsToSwapAre({ tokenA: 100, tokenB: 200 });
 
       const swapRatio2: SwapRatio = { tokenA: 1, tokenB: 1 };
@@ -140,14 +138,14 @@ contract('DCAHub', () => {
       const sarahsPosition1 = await deposit({
         depositor: sarah,
         token: tokenA,
-        swapInterval: SWAP_INTERVAL_15_MINUTES,
+        swapInterval: SwapInterval.FIFTEEN_MINUTES,
         rate: 500,
         swaps: 3,
       });
       const sarahsPosition2 = await deposit({
         depositor: sarah,
         token: tokenB,
-        swapInterval: SWAP_INTERVAL_15_MINUTES,
+        swapInterval: SwapInterval.FIFTEEN_MINUTES,
         rate: 100,
         swaps: 4,
       });
@@ -163,9 +161,9 @@ contract('DCAHub', () => {
       await assertHubBalanceDifferencesAre({ tokenA: -400 });
       await assertBalanceDifferencesAre(john, { tokenA: +400 });
 
-      await evm.advanceTimeAndBlock(SWAP_INTERVAL_1_HOUR);
+      await evm.advanceTimeAndBlock(SwapInterval.ONE_HOUR.seconds);
 
-      await assertIntervalsToSwapNowAre(SWAP_INTERVAL_15_MINUTES, SWAP_INTERVAL_1_HOUR);
+      await assertIntervalsToSwapNowAre(SwapInterval.FIFTEEN_MINUTES, SwapInterval.ONE_HOUR);
       await assertAmountsToSwapAre({ tokenA: 550, tokenB: 300 });
 
       await flashSwap({ callee: DCAHubSwapCallee });
@@ -215,9 +213,9 @@ contract('DCAHub', () => {
       const swapRatio3: SwapRatio = { tokenA: 1, tokenB: 2 };
       await setSwapFee(swapFee2);
       await setSwapRatio(swapRatio3);
-      await evm.advanceTimeAndBlock(SWAP_INTERVAL_1_HOUR);
+      await evm.advanceTimeAndBlock(SwapInterval.ONE_HOUR.seconds);
 
-      await assertIntervalsToSwapNowAre(SWAP_INTERVAL_15_MINUTES, SWAP_INTERVAL_1_HOUR);
+      await assertIntervalsToSwapNowAre(SwapInterval.FIFTEEN_MINUTES, SwapInterval.ONE_HOUR);
       await assertAmountsToSwapAre({ tokenA: 545, tokenB: 100 });
 
       await flashSwap({ callee: DCAHubSwapCallee });
@@ -239,8 +237,8 @@ contract('DCAHub', () => {
       await assertBalanceDifferencesAre(DCAHubSwapCallee, { tokenA: +495, tokenB: -988.02 });
       await assertPlatformBalanceIncreasedBy({ tokenA: +0.1, tokenB: +0.2 });
 
-      await evm.advanceTimeAndBlock(SWAP_INTERVAL_1_HOUR);
-      await assertIntervalsToSwapNowAre(SWAP_INTERVAL_15_MINUTES); // Even after waiting an hour, the 1 hour interval is not available. This is because it was marked as inactive on the last swap, since there were no more swaps on it
+      await evm.advanceTimeAndBlock(SwapInterval.ONE_HOUR.seconds);
+      await assertIntervalsToSwapNowAre(SwapInterval.FIFTEEN_MINUTES); // Even after waiting an hour, the 1 hour interval is not available. This is because it was marked as inactive on the last swap, since there were no more swaps on it
 
       await assertAmountsToSwapAre({ tokenA: 545, tokenB: 100 });
 
@@ -271,7 +269,7 @@ contract('DCAHub', () => {
       await assertBalanceDifferencesAre(DCAHubSwapCallee, { tokenA: +450, tokenB: -898.2 });
       await assertPlatformBalanceIncreasedBy({ tokenA: +0.1, tokenB: +0.2 });
 
-      await evm.advanceTimeAndBlock(SWAP_INTERVAL_15_MINUTES);
+      await evm.advanceTimeAndBlock(SwapInterval.FIFTEEN_MINUTES.seconds);
       await assertAmountsToSwapAre({ tokenA: 0, tokenB: 100 });
     });
 
@@ -362,7 +360,7 @@ contract('DCAHub', () => {
       token: TokenContract;
       depositor: SignerWithAddress;
       rate: number;
-      swapInterval: number;
+      swapInterval: SwapInterval;
       swaps: number;
     }): Promise<UserPositionDefinition> {
       const toToken = token.address === tokenA.address ? tokenB : tokenA;
@@ -373,7 +371,7 @@ contract('DCAHub', () => {
         toToken.address,
         token.asUnits(rate).mul(swaps),
         swaps,
-        swapInterval,
+        swapInterval.seconds,
         depositor.address,
         []
       );
@@ -383,7 +381,7 @@ contract('DCAHub', () => {
         owner: depositor,
         from: token,
         to: toToken,
-        swapInterval: BigNumber.from(swapInterval),
+        swapInterval,
         rate: token.asUnits(rate),
         amountOfSwaps: BigNumber.from(swaps),
       };
@@ -405,15 +403,8 @@ contract('DCAHub', () => {
       return (position: UserPositionDefinition) => calculateSwapped(position, ...swaps);
     }
 
-    async function assertNoSwapsCanBeExecutedNow() {
-      const [secondsUntilNext] = await DCAHub.secondsUntilNextSwap([{ tokenA: tokenA.address, tokenB: tokenB.address }]);
-      expect(secondsUntilNext).to.be.greaterThan(0);
-    }
-
-    async function assertThereAreNoSwapsAvailable() {
-      const [secondsUntilNext] = await DCAHub.secondsUntilNextSwap([{ tokenA: tokenA.address, tokenB: tokenB.address }]);
-      expect(secondsUntilNext).to.equal(MAX_UINT_32);
-      await assertIntervalsToSwapNowAre();
+    function assertNoSwapsCanBeExecutedNow() {
+      return assertIntervalsToSwapNowAre();
     }
 
     async function assertAmountsToSwapAre({ tokenA: expectedTokenA, tokenB: expectedTokenB }: { tokenA: number; tokenB: number }) {
@@ -422,33 +413,23 @@ contract('DCAHub', () => {
       let totalTokenA = constants.ZERO;
       let totalTokenB = constants.ZERO;
 
-      for (const interval of intervalsInSwap) {
-        if (interval > 0) {
-          const { nextAmountToSwapAToB, nextAmountToSwapBToA } = await DCAHub.swapData(
-            tokenA.address,
-            tokenB.address,
-            await DCAHub.intervalToMask(interval)
-          );
-          totalTokenA = totalTokenA.add(nextAmountToSwapAToB);
-          totalTokenB = totalTokenB.add(nextAmountToSwapBToA);
-        }
+      const intervals = SwapInterval.intervalsfromByte(intervalsInSwap);
+      for (const interval of intervals) {
+        const { nextAmountToSwapAToB, nextAmountToSwapBToA } = await DCAHub.swapData(tokenA.address, tokenB.address, interval.mask);
+        totalTokenA = totalTokenA.add(nextAmountToSwapAToB);
+        totalTokenB = totalTokenB.add(nextAmountToSwapBToA);
       }
 
       expect(totalTokenA).to.equal(tokenA.asUnits(expectedTokenA));
       expect(totalTokenB).to.equal(tokenB.asUnits(expectedTokenB));
     }
 
-    async function assertIntervalsToSwapNowAre(...swapIntervals: number[]): Promise<void> {
+    async function assertIntervalsToSwapNowAre(...swapIntervals: SwapInterval[]): Promise<void> {
       const nextSwapInfo = await getNextSwapInfo();
       const intervals = nextSwapInfo.pairs
         .map(({ intervalsInSwap }) => intervalsInSwap)
-        .flat()
-        .filter((interval) => interval > 0);
-      expect(intervals).to.eql(swapIntervals);
-      if (swapIntervals.length > 0) {
-        const [secondsUntilNext] = await DCAHub.secondsUntilNextSwap([{ tokenA: tokenA.address, tokenB: tokenB.address }]);
-        expect(secondsUntilNext).to.equal(0);
-      }
+        .reduce((a, b) => '0x' + (parseInt(a) | parseInt(b)).toString(16).padStart(2, '0'), '0x00');
+      expect(intervals).to.eql(SwapInterval.intervalsToByte(...swapIntervals));
     }
 
     function assertPositionIsConsistentWithNothingToWithdraw(position: UserPositionDefinition) {
@@ -462,7 +443,7 @@ contract('DCAHub', () => {
       const { from, to, swapInterval, rate, swapsExecuted, swapsLeft, remaining, swapped } = await getPosition(position);
       expect(from).to.equal(position.from.address);
       expect(to).to.equal(position.to.address);
-      expect(swapInterval).to.equal(position.swapInterval);
+      expect(swapInterval).to.equal(position.swapInterval.seconds);
       expect(rate).to.equal(position.rate);
       expect(swapsExecuted + swapsLeft).to.equal(position.amountOfSwaps);
       expect(remaining).to.equal(rate.mul(swapsLeft));
@@ -540,7 +521,7 @@ contract('DCAHub', () => {
       owner: SignerWithAddress;
       from: TokenContract;
       to: TokenContract;
-      swapInterval: BigNumber;
+      swapInterval: SwapInterval;
       rate: BigNumber;
       amountOfSwaps: BigNumber;
     };

--- a/test/unit/DCAHub/dca-hub-swap-handler.spec.ts
+++ b/test/unit/DCAHub/dca-hub-swap-handler.spec.ts
@@ -331,7 +331,7 @@ contract('DCAHubSwapHandler', () => {
     });
   });
 
-  describe('_getNextSwapInfo', () => {
+  describe('getNextSwapInfo', () => {
     type Pair = {
       tokenA: () => TokenContract;
       tokenB: () => TokenContract;
@@ -342,7 +342,7 @@ contract('DCAHubSwapHandler', () => {
 
     type Token = { token: () => TokenContract } & ({ CoW: number } | { platformFee: number }) & ({ required: number } | { reward: number } | {});
 
-    function internalGetNextSwapInfoTest({ title, pairs, result }: { title: string; pairs: Pair[]; result: Token[] }) {
+    function getNextSwapInfoTest({ title, pairs, result }: { title: string; pairs: Pair[]; result: Token[] }) {
       when(title, () => {
         let expectedRatios: Map<string, { ratioAToB: BigNumber; ratioBToA: BigNumber }>;
         let swapInformation: SwapInformation;
@@ -367,7 +367,7 @@ contract('DCAHubSwapHandler', () => {
             pairs.map(({ tokenA, tokenB }) => ({ tokenA: tokenA().address, tokenB: tokenB().address })),
             []
           );
-          swapInformation = await DCAHubSwapHandler.internalGetNextSwapInfo(tokens, pairIndexes);
+          swapInformation = await DCAHubSwapHandler.getNextSwapInfo(tokens, pairIndexes);
         });
 
         then('ratios are expose correctly', () => {
@@ -430,7 +430,7 @@ contract('DCAHubSwapHandler', () => {
         then('should revert with message', async () => {
           await behaviours.txShouldRevertWithMessage({
             contract: DCAHubSwapHandler,
-            func: 'internalGetNextSwapInfo',
+            func: 'getNextSwapInfo',
             args: [tokens.map((token) => token().address), pairs],
             message: error,
           });
@@ -438,13 +438,13 @@ contract('DCAHubSwapHandler', () => {
       });
     }
 
-    internalGetNextSwapInfoTest({
+    getNextSwapInfoTest({
       title: 'no pairs are sent',
       pairs: [],
       result: [],
     });
 
-    internalGetNextSwapInfoTest({
+    getNextSwapInfoTest({
       title: 'only one pair, but nothing to swap for token B',
       pairs: [
         {
@@ -469,7 +469,7 @@ contract('DCAHubSwapHandler', () => {
       ],
     });
 
-    internalGetNextSwapInfoTest({
+    getNextSwapInfoTest({
       title: 'only one pair, but nothing to swap for token A',
       pairs: [
         {
@@ -494,7 +494,7 @@ contract('DCAHubSwapHandler', () => {
       ],
     });
 
-    internalGetNextSwapInfoTest({
+    getNextSwapInfoTest({
       title: 'only one pair, with some CoW',
       pairs: [
         {
@@ -519,7 +519,7 @@ contract('DCAHubSwapHandler', () => {
       ],
     });
 
-    internalGetNextSwapInfoTest({
+    getNextSwapInfoTest({
       title: 'only one pair, with full CoW',
       pairs: [
         {
@@ -542,7 +542,7 @@ contract('DCAHubSwapHandler', () => {
       ],
     });
 
-    internalGetNextSwapInfoTest({
+    getNextSwapInfoTest({
       title: 'two pairs, no CoW between them',
       pairs: [
         {
@@ -580,7 +580,7 @@ contract('DCAHubSwapHandler', () => {
       ],
     });
 
-    internalGetNextSwapInfoTest({
+    getNextSwapInfoTest({
       title: 'two pairs, some CoW between them',
       pairs: [
         {
@@ -618,7 +618,7 @@ contract('DCAHubSwapHandler', () => {
       ],
     });
 
-    internalGetNextSwapInfoTest({
+    getNextSwapInfoTest({
       title: 'two pairs, full CoW between them',
       pairs: [
         {
@@ -655,7 +655,7 @@ contract('DCAHubSwapHandler', () => {
       ],
     });
 
-    internalGetNextSwapInfoTest({
+    getNextSwapInfoTest({
       title: 'two pairs, full CoW but swapper needs to provide platform fee',
       // This is a special scenario where we require the swapper to provide a token, just to pay it fully as platform fee
       pairs: [
@@ -753,103 +753,6 @@ contract('DCAHubSwapHandler', () => {
       tokens: [() => tokenB, () => tokenA],
       pairs: [{ indexTokenA: 0, indexTokenB: 1 }],
       error: 'InvalidTokens',
-    });
-  });
-
-  describe('getNextSwapInfo', () => {
-    type NextSwapInfo = {
-      tokens: {
-        token: string;
-        reward: BigNumber;
-        toProvide: BigNumber;
-        availableToBorrow: BigNumber;
-      }[];
-      pairs: { tokenA: string; tokenB: string; ratioAToB: BigNumber; ratioBToA: BigNumber; intervalsInSwap: number[] }[];
-    };
-
-    when('getNextSwapInfo is called', () => {
-      const INITIAL_BALANCE_TOKEN_A = BigNumber.from(100);
-      const INITIAL_BALANCE_TOKEN_B = BigNumber.from(200);
-      const INITIAL_BALANCE_TOKEN_C = BigNumber.from(300);
-
-      let internalSwapInformation: SwapInformation;
-      let result: NextSwapInfo;
-      let initialBalances: Map<string, BigNumber>;
-
-      given(async () => {
-        internalSwapInformation = {
-          tokens: [
-            {
-              token: tokenA.address,
-              reward: constants.ZERO,
-              toProvide: BigNumber.from(20),
-              platformFee: constants.ZERO,
-            },
-            {
-              token: tokenB.address,
-              reward: BigNumber.from(20),
-              toProvide: constants.ZERO,
-              platformFee: BigNumber.from(50),
-            },
-            {
-              token: tokenC.address,
-              reward: constants.ZERO,
-              toProvide: constants.ZERO,
-              platformFee: constants.ZERO,
-            },
-          ],
-          pairs: [
-            {
-              tokenA: tokenA.address,
-              tokenB: tokenB.address,
-              ratioAToB: BigNumber.from(10),
-              ratioBToA: BigNumber.from(10),
-              intervalsInSwap: await intervalsToByte(SWAP_INTERVAL, SWAP_INTERVAL_2),
-            },
-          ],
-        };
-
-        initialBalances = new Map([
-          [tokenA.address, INITIAL_BALANCE_TOKEN_A],
-          [tokenB.address, INITIAL_BALANCE_TOKEN_B],
-          [tokenC.address, INITIAL_BALANCE_TOKEN_C],
-        ]);
-
-        for (const token of [tokenA, tokenB, tokenC]) {
-          await token.mint(DCAHubSwapHandler.address, initialBalances.get(token.address)!);
-        }
-        await DCAHubSwapHandler.setInternalGetNextSwapInfo(internalSwapInformation);
-
-        result = await DCAHubSwapHandler.getNextSwapInfo([tokenA.address, tokenB.address, tokenC.address], [{ indexTokenA: 0, indexTokenB: 1 }]);
-      });
-
-      then('_getNextSwapInfo is called with the correct parameters', () => {
-        // TODO: We can't check this right now, because _getNextSwapInfo is a view, so we can't store the call in the contract's state.
-        // We will need to wait for smock to support it
-      });
-
-      then('pairs are returned correctly', () => {
-        expect(result.pairs.length).to.equal(1);
-        const [pair] = result.pairs;
-        const [expectedPair] = internalSwapInformation.pairs;
-        expect(pair.tokenA).to.eql(expectedPair.tokenA);
-        expect(pair.tokenB).to.eql(expectedPair.tokenB);
-        expect(pair.ratioAToB).to.eql(expectedPair.ratioAToB);
-        expect(pair.ratioBToA).to.eql(expectedPair.ratioBToA);
-        expect(pair.intervalsInSwap).to.eql([SWAP_INTERVAL, SWAP_INTERVAL_2, 0, 0, 0, 0, 0, 0]);
-      });
-
-      then('tokens are returned correctly', () => {
-        for (let i = 0; i < result.tokens.length; i++) {
-          const token = result.tokens[i];
-          const internalTokenInfo = internalSwapInformation.tokens[i];
-          expect(token.token).to.equal(internalTokenInfo.token);
-          expect(token.toProvide).to.equal(internalTokenInfo.toProvide);
-          expect(token.reward).to.equal(internalTokenInfo.reward);
-          const balance = initialBalances.get(token.token)!;
-          expect(token.availableToBorrow).to.equal(balance.sub(internalTokenInfo.reward));
-        }
-      });
     });
   });
 
@@ -1361,124 +1264,7 @@ contract('DCAHubSwapHandler', () => {
     });
   });
 
-  describe('secondsUntilNextSwap', () => {
-    secondsUntilNextSwapTest({
-      title: 'no pairs are passed',
-      pairs: [],
-      currentTimestamp: 1000,
-      expected: [],
-    });
-
-    secondsUntilNextSwapTest({
-      title: 'there are not active intervals for the given pair',
-      pairs: [
-        {
-          tokenA: () => tokenA,
-          tokenB: () => tokenB,
-          intervals: [],
-        },
-      ],
-      currentTimestamp: 1000,
-      expected: [2 ** 32 - 1],
-    });
-
-    secondsUntilNextSwapTest({
-      title: 'one of the intervals can be swapped for the given pair',
-      pairs: [
-        {
-          tokenA: () => tokenA,
-          tokenB: () => tokenB,
-          intervals: [
-            {
-              interval: SWAP_INTERVAL,
-              nextAvailable: 1000,
-            },
-            {
-              interval: SWAP_INTERVAL_2,
-              nextAvailable: 1001,
-            },
-          ],
-        },
-      ],
-      currentTimestamp: 1000,
-      expected: [0],
-    });
-
-    secondsUntilNextSwapTest({
-      title: 'none of the intervals can be swapped right now for the given pair',
-      pairs: [
-        {
-          tokenA: () => tokenA,
-          tokenB: () => tokenB,
-          intervals: [
-            {
-              interval: SWAP_INTERVAL,
-              nextAvailable: 1500,
-            },
-            {
-              interval: SWAP_INTERVAL_2,
-              nextAvailable: 1200,
-            },
-          ],
-        },
-      ],
-      currentTimestamp: 1000,
-      expected: [200],
-    });
-
-    secondsUntilNextSwapTest({
-      title: 'many pairs are provided',
-      pairs: [
-        {
-          tokenA: () => tokenA,
-          tokenB: () => tokenB,
-          intervals: [{ interval: SWAP_INTERVAL_2, nextAvailable: 1200 }],
-        },
-        {
-          tokenA: () => tokenA,
-          tokenB: () => tokenC,
-          intervals: [{ interval: SWAP_INTERVAL, nextAvailable: 500 }],
-        },
-      ],
-      currentTimestamp: 1000,
-      expected: [200, 0],
-    });
-
-    async function secondsUntilNextSwapTest({
-      title,
-      pairs,
-      currentTimestamp,
-      expected,
-    }: {
-      title: string;
-      pairs: {
-        tokenA: () => TokenContract;
-        tokenB: () => TokenContract;
-        intervals: { interval: number; nextAvailable: number }[];
-      }[];
-      currentTimestamp: number;
-      expected: number[];
-    }) {
-      when(title, () => {
-        given(async () => {
-          for (const { tokenA, tokenB, intervals } of pairs) {
-            for (const { interval, nextAvailable } of intervals) {
-              await DCAHubSwapHandler.addActiveSwapInterval(tokenA().address, tokenB().address, interval);
-              await DCAHubSwapHandler.setNextSwapAvailable(tokenA().address, tokenB().address, interval, nextAvailable);
-            }
-          }
-          await DCAHubSwapHandler.setBlockTimestamp(currentTimestamp);
-        });
-
-        then('result is as expected', async () => {
-          const input = pairs.map(({ tokenA, tokenB }) => ({ tokenA: tokenA().address, tokenB: tokenB().address }));
-          const result = await DCAHubSwapHandler.secondsUntilNextSwap(input);
-          expect(result).to.eql(expected);
-        });
-      });
-    }
-  });
-
+  // TODO: Update and use new intervals helper
   async function intervalsToByte(...intervals: number[]) {
     if (intervals.length === 0) {
       return '0x00';


### PR DESCRIPTION
Before this change, it could happen that a pair was swapped only to clean the active intervals state. No tokens were actually swapped, but one or more intervals were removed from the "active intervals" list.

Now, we are not allowing this to happen. We want to "clean" the active intervals list only as part of an actual swap. If no swaps are needed, then we won't clean the list