### PR TITLE
perf: small optimization in swap

### DIFF
--- a/contracts/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/DCAHub/DCAHubSwapHandler.sol
@@ -257,7 +257,9 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
 
     uint256[] memory _beforeBalances = new uint256[](_swapInformation.tokens.length);
     for (uint256 i; i < _beforeBalances.length; i++) {
-      _beforeBalances[i] = IERC20Metadata(_swapInformation.tokens[i].token).balanceOf(address(this));
+      if (_swapInformation.tokens[i].toProvide > 0 || _borrow[i] > 0) {
+        _beforeBalances[i] = IERC20Metadata(_swapInformation.tokens[i].token).balanceOf(address(this));
+      }
     }
 
     // Optimistically transfer tokens
@@ -274,20 +276,25 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
     }
 
     for (uint256 i; i < _swapInformation.tokens.length; i++) {
-      uint256 _amountToHave = _beforeBalances[i] + _swapInformation.tokens[i].toProvide - _swapInformation.tokens[i].reward;
+      uint256 _addToPlatformBalance = _swapInformation.tokens[i].platformFee;
 
-      // TODO: Check if it's cheaper to avoid checking the balance for tokens that had nothing to provide and that weren't borrowed
-      uint256 _currentBalance = IERC20Metadata(_swapInformation.tokens[i].token).balanceOf(address(this));
+      if (_swapInformation.tokens[i].toProvide > 0 || _borrow[i] > 0) {
+        uint256 _amountToHave = _beforeBalances[i] + _swapInformation.tokens[i].toProvide - _swapInformation.tokens[i].reward;
 
-      // Make sure tokens were sent back
-      if (_currentBalance < _amountToHave) {
-        revert IDCAHub.LiquidityNotReturned();
+        uint256 _currentBalance = IERC20Metadata(_swapInformation.tokens[i].token).balanceOf(address(this));
+
+        // Make sure tokens were sent back
+        if (_currentBalance < _amountToHave) {
+          revert IDCAHub.LiquidityNotReturned();
+        }
+
+        // Any extra tokens that might have been received, are set as platform balance
+        _addToPlatformBalance += (_currentBalance - _amountToHave);
       }
 
       // Update platform balance
-      uint256 _newPlatformBalance = _swapInformation.tokens[i].platformFee + (_currentBalance - _amountToHave);
-      if (_newPlatformBalance > 0) {
-        platformBalance[_swapInformation.tokens[i].token] += _newPlatformBalance;
+      if (_addToPlatformBalance > 0) {
+        platformBalance[_swapInformation.tokens[i].token] += _addToPlatformBalance;
       }
     }
 


### PR DESCRIPTION
We are now making a small change that would, in some cases, avoid the need to check a token's balance before and after the callback. Basically, when we don't expect the swapper to provide or return (after borrowing) tokens, we simply don't check its balance.

The benefit of doing this is, of course, gas savings. The drawback, is that if for some reason, we would get some extra tokens during swap from "reward"  tokens, they would be lost. To be honest, I'm not sure how likely it is to happen.

Note: for some reason, the gas report is not working correctly, so I checked it manually. Savings are 5K gas
```
|  Contract                       ·  Method ·  Min        ·  Max        ·  Avg        ·  # calls      ·  usd (avg)  │
```
Before:
```
|  DCAHub                         ·  swap ·     321889  ·     497395  ·     391849  ·           14  ·          -  │
```
After:
```
|  DCAHub                         ·  swap ·     314630  ·     495088  ·     386005  ·           14  ·          -  │
```