### PR TITLE
refactor: trying to use less storage

### DIFF
--- a/test/unit/DCAHub/dca-hub-position-handler.spec.ts
+++ b/test/unit/DCAHub/dca-hub-position-handler.spec.ts
@@ -16,7 +16,7 @@ import { SwapInterval } from 'js-lib/interval-utils';
 
 chai.use(smock.matchers);
 
-contract.only('DCAPositionHandler', () => {
+contract('DCAPositionHandler', () => {
   const PERFORMED_SWAPS_10 = 10;
   const POSITION_RATE_5 = 5;
   const POSITION_SWAPS_TO_PERFORM_10 = 10;


### PR DESCRIPTION
I realized that we were using 3 storage slots instead of 2, mainly because the rate was too big. We are now splitting the rate into two different uints, so we can use only 2 storage slots. There is a higher cost of calculating the original rate back from the split version, but the savings in `deposit` seem to make it worth it.

_Note: I have no idea how we are going to bring the bytecode size back to <24Kb haha_