### PR TITLE
chore: replace public with external

### DIFF
--- a/contracts/DCAHub/DCAHubConfigHandler.sol
+++ b/contracts/DCAHub/DCAHubConfigHandler.sol
@@ -90,7 +90,7 @@ abstract contract DCAHubConfigHandler is DCAHubParameters, AccessControl, Pausab
   }
 
   // solhint-disable-next-line func-name-mixedcase
-  function FEE_PRECISION() public pure returns (uint32) {
+  function FEE_PRECISION() external pure returns (uint32) {
     return FeeMath.FEE_PRECISION;
   }
 

--- a/contracts/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/DCAHub/DCAHubSwapHandler.sol
@@ -203,7 +203,7 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
     uint256[] calldata _borrow,
     address _to,
     bytes calldata _data
-  ) public nonReentrant whenNotPaused {
+  ) external nonReentrant whenNotPaused {
     SwapInfo memory _swapInformation;
     // Note: we are caching this variable in memory so we can read storage only once (it's cheaper that way)
     uint32 _swapFee = swapFee;


### PR DESCRIPTION
We are replacing some unnecessary uses of `public` with `external`