### PR TITLE
test: add chain id tests for permits

### DIFF
--- a/test/unit/DCAPermissionsManager/dca-permissions-manager.spec.ts
+++ b/test/unit/DCAPermissionsManager/dca-permissions-manager.spec.ts
@@ -13,7 +13,7 @@ import { BigNumber } from '@ethersproject/bignumber';
 import { _TypedDataEncoder } from '@ethersproject/hash';
 import { fromRpcSig } from 'ethereumjs-util';
 
-contract.only('DCAPermissionsManager', () => {
+contract('DCAPermissionsManager', () => {
   const NFT_NAME = 'Mean Finance DCA';
   const NFT_DESCRIPTOR = wallet.generateRandomAddress();
   let hub: SignerWithAddress, governor: SignerWithAddress;


### PR DESCRIPTION
We are now adding some test that make sure that permits are chain-specific. They already were, but we are now adding tests to make sure 