### PR TITLE
refactor: use latest round data

### DIFF
--- a/contracts/interfaces/oracles/IChainlinkOracle.sol
+++ b/contracts/interfaces/oracles/IChainlinkOracle.sol
@@ -41,6 +41,12 @@ interface IChainlinkOracle is IPriceOracle {
   /// @param mappings Their new mappings
   event MappingsAdded(address[] tokens, address[] mappings);
 
+  /// @notice Thrown when the price is non-positive
+  error InvalidPrice();
+
+  /// @notice Thrown when the last price update was too long ago
+  error LastUpdateIsTooOld();
+
   /// @notice Returns the Chainlink feed registry
   /// @return The Chainlink registry
   function registry() external view returns (FeedRegistryInterface);

--- a/contracts/mocks/oracles/ChainlinkOracle.sol
+++ b/contracts/mocks/oracles/ChainlinkOracle.sol
@@ -42,6 +42,10 @@ contract ChainlinkOracleMock is ChainlinkOracle {
     _pricingPlan[__tokenA][__tokenB] = MockedPricingPlan({plan: _plan, isSet: true});
   }
 
+  function intercalCallRegistry(address _quote, address _base) external view returns (uint256) {
+    return _callRegistry(_quote, _base);
+  }
+
   function _determinePricingPlan(address _tokenA, address _tokenB) internal view override returns (PricingPlan) {
     (address __tokenA, address __tokenB) = TokenSorting.sortTokens(_tokenA, _tokenB);
     MockedPricingPlan memory _plan = _pricingPlan[__tokenA][__tokenB];


### PR DESCRIPTION
We are now making a few changes so that we use `latestRoundData` instead of `latestAnswer` when we call the feed registry.

Also, we are now reverting when:
1. The price is non-positive
2. The last update was more than 24hs ago (if you check the [docs](https://docs.chain.link/docs/ethereum-addresses/), all heartbeats are at most 24hs long)