### PR TITLE
perf: avoid sending 0 tokens

### DIFF
--- a/contracts/DCAHub/DCAHubPositionHandler.sol
+++ b/contracts/DCAHub/DCAHubPositionHandler.sol
@@ -193,10 +193,12 @@ abstract contract DCAHubPositionHandler is ReentrancyGuard, DCAHubConfigHandler,
     _removeFromDelta(_userPosition, _performedSwaps);
     _addToDelta(_userPosition.from, _userPosition.to, _userPosition.swapIntervalMask, _finalSwap, _newRate);
 
-    if (_increase) {
-      IERC20Metadata(_userPosition.from).safeTransferFrom(msg.sender, address(this), _amount);
-    } else {
-      IERC20Metadata(_userPosition.from).safeTransfer(_recipient, _amount);
+    if (_amount > 0) {
+      if (_increase) {
+        IERC20Metadata(_userPosition.from).safeTransferFrom(msg.sender, address(this), _amount);
+      } else {
+        IERC20Metadata(_userPosition.from).safeTransfer(_recipient, _amount);
+      }
     }
 
     emit Modified(msg.sender, _positionId, _newRate, _performedSwaps + 1, _finalSwap);

--- a/contracts/interfaces/IDCAHub.sol
+++ b/contracts/interfaces/IDCAHub.sol
@@ -230,6 +230,7 @@ interface IDCAHubPositionHandler {
   /// @param _amountOfSwaps How many swaps to execute for this position
   /// @param _swapInterval How frequently the position's swaps should be executed
   /// @param _owner The address of the owner of the position being created
+  /// @param _permissions Extra permissions to add to the position. Can be empty
   /// @return _positionId The id of the created position
   function deposit(
     address _from,
@@ -267,7 +268,6 @@ interface IDCAHubPositionHandler {
   /// @dev Will revert:
   /// With InvalidPosition if _positionId is invalid
   /// With UnauthorizedCaller if the caller doesn't have access to the position
-  /// With ZeroAmount if _amount is zero
   /// With AmountTooBig if _amount is too big
   /// @param _positionId The position's id
   /// @param _amount Amount of funds to add to the position

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -64,6 +64,11 @@ const networks: NetworksUserConfig = process.env.TEST
         accounts: accounts('optimism'),
         tags: ['production'],
       },
+      'optimism-kovan': {
+        url: 'https://kovan.optimism.io',
+        accounts: accounts('optimism'),
+        tags: ['production'],
+      },
     };
 
 const config: HardhatUserConfig = {


### PR DESCRIPTION
We are making a really small optimization, where we avoid sending transfering tokens in `amount` is 0