### PR TITLE
refactor: deploys through factory

### DIFF
--- a/deploy/000_factory.ts
+++ b/deploy/000_factory.ts
@@ -1,0 +1,16 @@
+import { HardhatRuntimeEnvironment } from 'hardhat/types';
+import { DeployFunction } from 'hardhat-deploy/types';
+
+const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { deployer } = await hre.getNamedAccounts();
+
+  await hre.deployments.deploy('Factory', {
+    contract: 'contracts/utils/Factory.sol:Factory',
+    from: deployer,
+    args: [],
+    log: true,
+  });
+};
+
+deployFunction.tags = ['Factory'];
+export default deployFunction;

--- a/deploy/002_uniswap_oracle.ts
+++ b/deploy/002_uniswap_oracle.ts
@@ -1,17 +1,35 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import { DeployFunction } from 'hardhat-deploy/types';
+import { getCreationCode } from '@test-utils/contracts';
+import { ethers } from 'hardhat';
+import { utils } from 'ethers';
+import { bytecode } from '@artifacts/contracts/oracles/UniswapV3Oracle.sol/UniswapV3Oracle.json';
 
 const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployer, governor } = await hre.getNamedAccounts();
 
   const UNISWAP_V3_FACTORY_ADDRESS = '0x1F98431c8aD98523631AE4a59f267346ea31F984';
 
-  await hre.deployments.deploy('UniswapOracle', {
-    contract: 'contracts/oracles/UniswapV3Oracle.sol:UniswapV3Oracle',
-    from: deployer,
-    args: [governor, UNISWAP_V3_FACTORY_ADDRESS],
-    log: true,
-  });
+  await hre.deployments.execute(
+    'Factory',
+    {
+      from: deployer,
+      log: true,
+    },
+    'deploy',
+    utils.formatBytes32String('grizz'),
+    getCreationCode({
+      bytecode,
+      constructorArgs: {
+        types: ['address', 'address'],
+        values: [governor, UNISWAP_V3_FACTORY_ADDRESS],
+      },
+    })
+  );
+
+  const deployment = await hre.deployments.getDeploymentsFromAddress((await ethers.getContract('Factory')).address);
+
+  hre.deployments.save('UniswapOracle', deployment[1]);
 };
 
 deployFunction.tags = ['UniswapOracle'];

--- a/test/utils/contracts.ts
+++ b/test/utils/contracts.ts
@@ -3,7 +3,7 @@ import { TransactionResponse } from '@ethersproject/abstract-provider';
 import { ContractInterface, ethers, Signer } from 'ethers';
 import { getStatic, ParamType } from 'ethers/lib/utils';
 
-const deploy = async (contract: ContractFactory, args: any[]): Promise<{ tx: TransactionResponse; contract: Contract }> => {
+export const deploy = async (contract: ContractFactory, args: any[]): Promise<{ tx: TransactionResponse; contract: Contract }> => {
   const deploymentTransactionRequest = await contract.getDeployTransaction(...args);
   const deploymentTx = await contract.signer.sendTransaction(deploymentTransactionRequest);
   const contractAddress = getStatic<(deploymentTx: TransactionResponse) => string>(contract.constructor, 'getContractAddress')(deploymentTx);
@@ -17,7 +17,7 @@ const deploy = async (contract: ContractFactory, args: any[]): Promise<{ tx: Tra
   };
 };
 
-const getCreationCode = ({
+export const getCreationCode = ({
   bytecode,
   constructorArgs,
 }: {

--- a/test/utils/event-utils.ts
+++ b/test/utils/event-utils.ts
@@ -1,5 +1,6 @@
 import { TransactionResponse, TransactionReceipt } from '@ethersproject/abstract-provider';
 import { expect } from 'chai';
+import { Receipt } from 'hardhat-deploy/types';
 
 export async function expectNoEventWithName(response: TransactionResponse, eventName: string) {
   const receipt = await response.wait();
@@ -10,6 +11,14 @@ export async function expectNoEventWithName(response: TransactionResponse, event
 
 export async function readArgFromEvent<T>(response: TransactionResponse, eventName: string, paramName: string): Promise<T | undefined> {
   const receipt = await response.wait();
+  for (const event of getEvents(receipt)) {
+    if (event.event === eventName) {
+      return event.args[paramName];
+    }
+  }
+}
+
+export async function readArgFromReceipt<T>(receipt: Receipt, eventName: string, paramName: string): Promise<T | undefined> {
   for (const event of getEvents(receipt)) {
     if (event.event === eventName) {
       return event.args[paramName];
@@ -35,7 +44,7 @@ export async function getEventArgs<T>(response: TransactionResponse, eventName: 
   throw new Error(`Failed to find event with name ${eventName}`);
 }
 
-function getEvents(receipt: TransactionReceipt): Event[] {
+function getEvents(receipt: TransactionReceipt | Receipt): Event[] {
   // @ts-ignore
   return receipt.events;
 }


### PR DESCRIPTION
We start deploying our contracts through the `Factory`. We need to inform manually the deployments to `hardhat-deploy` since we are not actually using the "normal" workflow for deployment.

There is a trade off there: JSON deployments will no longer (at least from what I've managed to achieve) the `devdoc` and the `storageLayout` parameters filled correctly. 

WDYT about this new way of deploying ?

EDIT: Oh no ! After seeing that it breaks integrations ... It seems that it also doesn't save the correct ABI 😭  - I could build some tooling around this, and take the ABI, storageLayout and devdoc from artifacts and insert it in the deployment file. Again, wdyt ?