### PR TITLE
feat: adds total supply to nft

### DIFF
--- a/contracts/DCAPermissionsManager/DCAPermissionsManager.sol
+++ b/contracts/DCAPermissionsManager/DCAPermissionsManager.sol
@@ -37,6 +37,8 @@ contract DCAPermissionsManager is ERC721, EIP712, Governable, IDCAPermissionMana
   mapping(address => uint256) public nonces;
   mapping(uint256 => uint256) public lastOwnershipChange;
   mapping(uint256 => mapping(address => TokenPermission)) public tokenPermissions;
+  /// @inheritdoc IERC721BasicEnumerable
+  uint256 public override totalSupply;
 
   constructor(address _governor, IDCATokenDescriptor _descriptor)
     ERC721('Mean Finance - DCA Position', 'MF-DCA-P')
@@ -63,6 +65,7 @@ contract DCAPermissionsManager is ERC721, EIP712, Governable, IDCAPermissionMana
     if (msg.sender != hub) revert OnlyHubCanExecute();
     _mint(_owner, _id);
     _setPermissions(_id, _permissions);
+    ++totalSupply;
   }
 
   /// @inheritdoc IDCAPermissionManager
@@ -108,6 +111,7 @@ contract DCAPermissionsManager is ERC721, EIP712, Governable, IDCAPermissionMana
   function burn(uint256 _id) external {
     if (msg.sender != hub) revert OnlyHubCanExecute();
     _burn(_id);
+    --totalSupply;
   }
 
   /// @inheritdoc IDCAPermissionManager

--- a/contracts/interfaces/IDCAPermissionManager.sol
+++ b/contracts/interfaces/IDCAPermissionManager.sol
@@ -4,9 +4,16 @@ pragma solidity >=0.8.7 <0.9.0;
 import '@openzeppelin/contracts/token/ERC721/IERC721.sol';
 import './IDCATokenDescriptor.sol';
 
+interface IERC721BasicEnumerable {
+  /// @notice Count NFTs tracked by this contract
+  /// @return A count of valid NFTs tracked by this contract, where each one of
+  /// them has an assigned and queryable owner not equal to the zero address
+  function totalSupply() external view returns (uint256);
+}
+
 /// @title The interface for all permission related matters
 /// @notice These methods allow users to set and remove permissions to their positions
-interface IDCAPermissionManager is IERC721 {
+interface IDCAPermissionManager is IERC721, IERC721BasicEnumerable {
   /// @notice Set of possible permissions
   enum Permission {
     INCREASE,

--- a/test/unit/DCAPermissionsManager/dca-permissions-manager.spec.ts
+++ b/test/unit/DCAPermissionsManager/dca-permissions-manager.spec.ts
@@ -229,9 +229,15 @@ contract('DCAPermissionsManager', () => {
       const OWNER = wallet.generateRandomAddress();
       const OPERATOR = constants.NOT_ZERO_ADDRESS;
       let tx: TransactionResponse;
+      let initialTotalSupply: BigNumber;
 
       given(async () => {
+        initialTotalSupply = await DCAPermissionsManager.totalSupply();
         tx = await DCAPermissionsManager.mint(TOKEN_ID, OWNER, [{ operator: OPERATOR, permissions: [Permission.WITHDRAW] }]);
+      });
+
+      then('increases total supply', async () => {
+        expect(await DCAPermissionsManager.totalSupply()).to.equal(initialTotalSupply.add(1));
       });
 
       then('owner has all permisisons', async () => {
@@ -307,8 +313,13 @@ contract('DCAPermissionsManager', () => {
       });
     });
     when('the hub is the caller', () => {
+      let initialTotalSupply: BigNumber;
       given(async () => {
+        initialTotalSupply = await DCAPermissionsManager.totalSupply();
         await DCAPermissionsManager.burn(TOKEN_ID);
+      });
+      then('totalSupply gets decreased', async () => {
+        expect(await DCAPermissionsManager.totalSupply()).to.equal(initialTotalSupply.sub(1));
       });
       then('nft is burned', async () => {
         const balance = await DCAPermissionsManager.balanceOf(OWNER);


### PR DESCRIPTION
This is a bit weird of a PR. ERC721 that have `totalSupply()` usually gets it inherited by `IERC721Enumberable` (https://eips.ethereum.org/EIPS/eip-721 under enumerable section). But ... I don't think we want to comply with all the interface.

This is basically to fix etherscan's UI
<img width="631" alt="image" src="https://user-images.githubusercontent.com/97693615/164563805-855d21e6-868f-4f01-8009-f3a189b1ec81.png">
