### PR TITLE
fix: avoid losing precision

### DIFF
--- a/contracts/DCAHub/DCAHubPositionHandler.sol
+++ b/contracts/DCAHub/DCAHubPositionHandler.sol
@@ -5,6 +5,7 @@ import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
 import '@openzeppelin/contracts/utils/math/SafeMath.sol';
 import '../libraries/Intervals.sol';
 import './DCAHubConfigHandler.sol';
+import '../libraries/FeeMath.sol';
 
 abstract contract DCAHubPositionHandler is ReentrancyGuard, DCAHubConfigHandler, IDCAHubPositionHandler {
   struct DCA {
@@ -328,7 +329,7 @@ abstract contract DCAHubPositionHandler is ReentrancyGuard, DCAHubConfigHandler,
     uint256 _magnitude = magnitude[_userPosition.from];
     uint120 _rate = _mergeRate(_userPosition);
     (bool _ok, uint256 _mult) = SafeMath.tryMul(_accumRatio, _rate);
-    uint256 _swappedInCurrentPosition = _ok ? _mult / _magnitude : (_accumRatio / _magnitude) * _rate;
+    uint256 _swappedInCurrentPosition = (_ok ? _mult / _magnitude : (_accumRatio / _magnitude) * _rate) / FeeMath.FEE_PRECISION;
     _swapped = _swappedInCurrentPosition + _swappedBeforeModified[_positionId];
   }
 

--- a/contracts/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/DCAHub/DCAHubSwapHandler.sol
@@ -296,7 +296,7 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
   }
 
   // Note: This is almost exactly as FeeMath.subtractFeeFromAmount, but without dividing by FEE_PRECISION.
-  // We will make that division when calculating how much was swapped. By doing so, we don't lose precision, which
+  // We will make that division when calculating how much was swapped. By doing so, we don't lose precision which,
   // in the case of tokens with a small amount of decimals (like USDC), can end up being a lot of funds
   function _subtractFeeFromAmount(uint32 _fee, uint256 _amount) internal pure returns (uint256) {
     return _amount * (FeeMath.FEE_PRECISION - _fee / 100);

--- a/contracts/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/DCAHub/DCAHubSwapHandler.sol
@@ -296,9 +296,9 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
   }
 
   // Note: This is almost exactly as FeeMath.subtractFeeFromAmount, but without dividing by FEE_PRECISION.
-  // We will make that division when calculating how much was swapped. By doing so, we don't loose precision, which
+  // We will make that division when calculating how much was swapped. By doing so, we don't lose precision, which
   // in the case of tokens with a small amount of decimals (like USDC), can end up being a lot of funds
   function _subtractFeeFromAmount(uint32 _fee, uint256 _amount) internal pure returns (uint256) {
-    return _amount * (FEE_PRECISION - _fee / 100);
+    return _amount * (FeeMath.FEE_PRECISION - _fee / 100);
   }
 }

--- a/contracts/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/DCAHub/DCAHubSwapHandler.sol
@@ -46,7 +46,7 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
     uint256 _rateFromTo,
     uint32 _swapFee
   ) internal pure returns (uint256 _amountTo) {
-    uint256 _numerator = _amountFrom * FeeMath.subtractFeeFromAmount(_swapFee, _rateFromTo);
+    uint256 _numerator = FeeMath.subtractFeeFromAmount(_swapFee, _amountFrom * _rateFromTo);
     _amountTo = _numerator / _fromTokenMagnitude;
     // Note: we need to round up because we can't ask for less than what we actually need
     if (_numerator % _fromTokenMagnitude != 0) _amountTo++;
@@ -222,8 +222,8 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
               _pairInSwap.tokenA,
               _pairInSwap.tokenB,
               _mask,
-              FeeMath.subtractFeeFromAmount(_swapFee, _pairInSwap.ratioAToB),
-              FeeMath.subtractFeeFromAmount(_swapFee, _pairInSwap.ratioBToA),
+              _subtractFeeFromAmount(_swapFee, _pairInSwap.ratioAToB),
+              _subtractFeeFromAmount(_swapFee, _pairInSwap.ratioBToA),
               _timestamp
             );
           }
@@ -293,5 +293,12 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
 
     // Emit event
     emit Swapped(msg.sender, _rewardRecipient, _callbackHandler, _swapInformation, _borrow, _swapFee);
+  }
+
+  // Note: This is almost exactly as FeeMath.subtractFeeFromAmount, but without dividing by FEE_PRECISION.
+  // We will make that division when calculating how much was swapped. By doing so, we don't loose precision, which
+  // in the case of tokens with a small amount of decimals (like USDC), can end up being a lot of funds
+  function _subtractFeeFromAmount(uint32 _fee, uint256 _amount) internal pure returns (uint256) {
+    return _amount * (FEE_PRECISION - _fee / 100);
   }
 }

--- a/test/e2e/DCAHub/precision-breaker.spec.ts
+++ b/test/e2e/DCAHub/precision-breaker.spec.ts
@@ -54,7 +54,7 @@ contract('DCAHub', () => {
       DCAPermissionsManager = await DCAPermissionsManagerFactory.deploy(constants.NOT_ZERO_ADDRESS, constants.NOT_ZERO_ADDRESS);
       DCAHub = await DCAHubFactory.deploy(governor.address, governor.address, priceOracle.address, DCAPermissionsManager.address);
       await DCAHub.connect(governor).grantRole(PLATFORM_WITHDRAW_ROLE, governor.address);
-      DCAPermissionsManager.setHub(DCAHub.address);
+      await DCAPermissionsManager.setHub(DCAHub.address);
       DCAHubSwapCallee = await DCAHubSwapCalleeFactory.deploy();
       await DCAHubSwapCallee.setInitialBalances([tokenA.address, tokenB.address], [tokenA.asUnits(2000), tokenB.asUnits(2000)]);
       await DCAHub.addSwapIntervalsToAllowedList([SwapInterval.ONE_HOUR.seconds]);

--- a/test/e2e/DCAHub/precision-low-decimal-tokens.spec.ts
+++ b/test/e2e/DCAHub/precision-low-decimal-tokens.spec.ts
@@ -28,14 +28,14 @@ contract('DCAHub', () => {
     let USDC: TokenContract, myToken: TokenContract;
     let DCAHubFactory: DCAHub__factory, DCAHub: DCAHub;
     let priceOracle: FakeContract<IPriceOracle>;
-    let DCAPermissionsManagerFactory: DCAPermissionsManager__factory, DCAPermissionsManager: DCAPermissionsManager;
+    let DCAPermissionsManager: DCAPermissionsManager;
     let DCAHubSwapCalleeFactory: DCAHubSwapCalleeMock__factory, DCAHubSwapCallee: DCAHubSwapCalleeMock;
     let snapshotId: string;
 
     before('Setup accounts and contracts', async () => {
       [governor, alice] = await ethers.getSigners();
       DCAHubFactory = await ethers.getContractFactory('contracts/DCAHub/DCAHub.sol:DCAHub');
-      DCAPermissionsManagerFactory = await ethers.getContractFactory(
+      const DCAPermissionsManagerFactory: DCAPermissionsManager__factory = await ethers.getContractFactory(
         'contracts/DCAPermissionsManager/DCAPermissionsManager.sol:DCAPermissionsManager'
       );
       DCAHubSwapCalleeFactory = await ethers.getContractFactory('contracts/mocks/DCAHubSwapCallee.sol:DCAHubSwapCalleeMock');

--- a/test/e2e/DCAHub/precision-low-decimal-tokens.spec.ts
+++ b/test/e2e/DCAHub/precision-low-decimal-tokens.spec.ts
@@ -1,0 +1,117 @@
+import { ethers } from 'hardhat';
+import {
+  DCAHub,
+  DCAHubSwapCalleeMock,
+  DCAHubSwapCalleeMock__factory,
+  DCAHub__factory,
+  DCAPermissionsManager,
+  DCAPermissionsManager__factory,
+  IPriceOracle,
+} from '@typechained';
+import { constants, erc20 } from '@test-utils';
+import { contract, given, then, when } from '@test-utils/bdd';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { TokenContract } from '@test-utils/erc20';
+import { FakeContract, smock } from '@defi-wonderland/smock';
+import { buildSwapInput } from 'js-lib/swap-utils';
+import { SwapInterval } from 'js-lib/interval-utils';
+import { BigNumber } from 'ethers';
+import { expect } from 'chai';
+
+contract('DCAHub', () => {
+  describe('Precision with low decimal tokens', () => {
+    const PRICE_IN_USDC = 100;
+
+    let governor: SignerWithAddress;
+    let alice: SignerWithAddress;
+    let USDC: TokenContract, myToken: TokenContract;
+    let DCAHubFactory: DCAHub__factory, DCAHub: DCAHub;
+    let priceOracle: FakeContract<IPriceOracle>;
+    let DCAPermissionsManagerFactory: DCAPermissionsManager__factory, DCAPermissionsManager: DCAPermissionsManager;
+    let DCAHubSwapCalleeFactory: DCAHubSwapCalleeMock__factory, DCAHubSwapCallee: DCAHubSwapCalleeMock;
+
+    before('Setup accounts and contracts', async () => {
+      [governor, alice] = await ethers.getSigners();
+      DCAHubFactory = await ethers.getContractFactory('contracts/DCAHub/DCAHub.sol:DCAHub');
+      DCAPermissionsManagerFactory = await ethers.getContractFactory(
+        'contracts/DCAPermissionsManager/DCAPermissionsManager.sol:DCAPermissionsManager'
+      );
+      DCAHubSwapCalleeFactory = await ethers.getContractFactory('contracts/mocks/DCAHubSwapCallee.sol:DCAHubSwapCalleeMock');
+    });
+
+    beforeEach('Deploy and configure', async () => {
+      USDC = await erc20.deploy({
+        name: 'USDC',
+        symbol: 'USDC',
+        decimals: 6,
+      });
+      myToken = await erc20.deploy({
+        name: 'MyTKN',
+        symbol: 'MyTKN',
+        decimals: 18,
+      });
+      priceOracle = await smock.fake('IPriceOracle');
+      priceOracle.quote.returns(PRICE_IN_USDC);
+      DCAPermissionsManager = await DCAPermissionsManagerFactory.deploy(constants.NOT_ZERO_ADDRESS, constants.NOT_ZERO_ADDRESS);
+      DCAHub = await DCAHubFactory.deploy(governor.address, governor.address, priceOracle.address, DCAPermissionsManager.address);
+      DCAPermissionsManager.setHub(DCAHub.address);
+      DCAHubSwapCallee = await DCAHubSwapCalleeFactory.deploy();
+
+      await DCAHubSwapCallee.setInitialBalances([USDC.address, myToken.address], [USDC.asUnits(2000000), myToken.asUnits(2000)]);
+      await DCAHub.addSwapIntervalsToAllowedList([SwapInterval.ONE_HOUR.seconds]);
+      await setInitialBalance(alice, { tokenA: 0, tokenB: 10000000 });
+      await setInitialBalance(DCAHubSwapCallee, { tokenA: 2000000, tokenB: 2000 });
+    });
+
+    when('position is created and swap is executed', () => {
+      let expectedSwapped: BigNumber, expectedPlatformFee: BigNumber;
+      given(async () => {
+        const amountToSwap = myToken.magnitude.mul(1000000);
+        await myToken.connect(alice).approve(DCAHub.address, constants.MAX_UINT_256);
+        await DCAHub.connect(alice)['deposit(address,address,uint256,uint32,uint32,address,(address,uint8[])[])'](
+          myToken.address,
+          USDC.address,
+          amountToSwap,
+          1,
+          SwapInterval.ONE_HOUR.seconds,
+          alice.address,
+          []
+        );
+
+        await swap({ callee: DCAHubSwapCallee });
+
+        expectedSwapped = amountToSwap.mul(PRICE_IN_USDC).mul(9940).div(10000).div(myToken.magnitude); // 99.4%
+        expectedPlatformFee = amountToSwap.mul(PRICE_IN_USDC).mul(15).div(10000).div(myToken.magnitude); // 0.15%
+      });
+
+      then('swapped balance is calculated correctly', async () => {
+        const positon = await DCAHub.connect(alice).userPosition(1);
+        expect(positon.swapped).to.equal(expectedSwapped);
+      });
+
+      then('hub balance is enough for the withdraw', async () => {
+        const hubBalance = await USDC.balanceOf(DCAHub.address);
+        console.log('hubBalance', hubBalance.toString());
+        console.log('expectedSwapped', expectedSwapped.toString());
+        expect(hubBalance).to.equal(expectedSwapped.add(expectedPlatformFee));
+      });
+    });
+
+    async function swap({ callee }: { callee: HasAddress }) {
+      const { tokens, pairIndexes, borrow } = buildSwapInput([{ tokenA: USDC.address, tokenB: myToken.address }], []);
+      await DCAHub.swap(tokens, pairIndexes, callee.address, callee.address, borrow, ethers.utils.randomBytes(5));
+    }
+
+    async function setInitialBalance(
+      hasAddress: HasAddress,
+      { tokenA: amountTokenA, tokenB: amountTokenB }: { tokenA: number; tokenB: number }
+    ) {
+      await USDC.mint(hasAddress.address, USDC.asUnits(amountTokenA));
+      await myToken.mint(hasAddress.address, myToken.asUnits(amountTokenB));
+    }
+
+    type HasAddress = {
+      readonly address: string;
+    };
+  });
+});

--- a/test/unit/DCAHub/dca-hub-swap-handler.spec.ts
+++ b/test/unit/DCAHub/dca-hub-swap-handler.spec.ts
@@ -19,8 +19,9 @@ import { buildGetNextSwapInfoInput, buildSwapInput } from 'js-lib/swap-utils';
 import { SwapInterval } from 'js-lib/interval-utils';
 import { FakeContract, smock } from '@defi-wonderland/smock';
 
-const CALCULATE_FEE = (bn: BigNumber) => bn.mul(6).div(1000);
-const APPLY_FEE = (bn: BigNumber) => bn.mul(994).div(1000);
+const CALCULATE_FEE = (bn: BigNumberish) => BigNumber.from(bn).mul(6).div(1000);
+const APPLY_FEE = (bn: BigNumberish) => BigNumber.from(bn).mul(FEE_PRECISION).mul(994).div(1000);
+const FEE_PRECISION = 10000;
 
 contract('DCAHubSwapHandler', () => {
   let owner: SignerWithAddress;
@@ -1093,8 +1094,8 @@ contract('DCAHubSwapHandler', () => {
           for (const pair of pairs) {
             for (const interval of pair.intervalsInSwap) {
               const call = await DCAHubSwapHandler.registerSwapCalls(pair.tokenA().address, pair.tokenB().address, interval.mask);
-              expect(call.ratioAToB).to.equal(APPLY_FEE(BigNumber.from(pair.ratioAToB)));
-              expect(call.ratioBToA).to.equal(APPLY_FEE(BigNumber.from(pair.ratioBToA)));
+              expect(call.ratioAToB).to.equal(APPLY_FEE(pair.ratioAToB));
+              expect(call.ratioBToA).to.equal(APPLY_FEE(pair.ratioBToA));
               expect(call.timestamp).to.equal(BLOCK_TIMESTAMP);
             }
           }


### PR DESCRIPTION
In this PR, we are being more careful when dividing by `FeeMath.FEE_PRECISION`. We realized that with the previous code, in some cases, we could end up losing precision. This happened in pairs where one of the tokens had a small number of decimals (like USDC), and the other token had a really low value against it.

So, for example, if 1 token of `MyTKN` was worth 0.0001 USD, then it would be '100' units against USDC. With such a low amount of units, we could end up losing close to 0.4% when dividing by `FeeMath.FEE_PRECISION`

We checked and this wasn't the case in any of the pairs in v2, but we can fix it before relaunching