### PR TITLE
feat: adds allowed tokens to swap handler

### DIFF
--- a/contracts/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/DCAHub/DCAHubSwapHandler.sol
@@ -166,6 +166,7 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
 
     _swapInformation.tokens = new TokenInSwap[](_tokens.length);
     for (uint256 i; i < _swapInformation.tokens.length; i++) {
+      if (!_allowedTokens[_tokens[i]]) revert IDCAHubConfigHandler.UnallowedToken();
       if (i > 0 && _tokens[i] <= _tokens[i - 1]) {
         revert IDCAHub.InvalidTokens();
       }
@@ -241,6 +242,7 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
     uint256[] memory _beforeBalances = new uint256[](_swapInformation.tokens.length);
     for (uint256 i; i < _swapInformation.tokens.length; i++) {
       TokenInSwap memory _tokenInSwap = _swapInformation.tokens[i];
+
       uint256 _amountToBorrow = _borrow[i];
 
       // Remember balances before callback

--- a/test/unit/DCAHub/dca-hub-swap-handler.spec.ts
+++ b/test/unit/DCAHub/dca-hub-swap-handler.spec.ts
@@ -50,6 +50,7 @@ contract('DCAHubSwapHandler', () => {
 
     priceOracle = await smock.fake('IPriceOracle');
     DCAHubSwapHandler = await DCAHubSwapHandlerContract.deploy(owner.address, owner.address, priceOracle.address);
+    await DCAHubSwapHandler.setAllowedTokens([tokenA.address, tokenB.address, tokenC.address], [true, true, true]);
     snapshotId = await snapshot.take();
   });
 
@@ -906,6 +907,28 @@ contract('DCAHubSwapHandler', () => {
       error: 'InvalidTokens',
       context: async () => {
         await DCAHubSwapHandler.setMagnitude([tokenA.address, tokenB.address]);
+      },
+    });
+
+    failedGetNextSwapInfoTest({
+      title: 'tokenA is not allowed',
+      tokens: [() => tokenA, () => tokenB],
+      pairs: [{ indexTokenA: 0, indexTokenB: 1 }],
+      error: 'UnallowedToken',
+      context: async () => {
+        await DCAHubSwapHandler.setMagnitude([tokenA.address, tokenB.address]);
+        await DCAHubSwapHandler.setAllowedTokens([tokenA.address], [false]);
+      },
+    });
+
+    failedGetNextSwapInfoTest({
+      title: 'tokenB is not allowed',
+      tokens: [() => tokenA, () => tokenB],
+      pairs: [{ indexTokenA: 0, indexTokenB: 1 }],
+      error: 'UnallowedToken',
+      context: async () => {
+        await DCAHubSwapHandler.setMagnitude([tokenA.address, tokenB.address]);
+        await DCAHubSwapHandler.setAllowedTokens([tokenB.address], [false]);
       },
     });
   });


### PR DESCRIPTION
Adds allowed tokens to swap workflow. We will test that swap through e2e gets reverted in another PR, since our units modify the return of getNextSwapInformation thus making it not-easily-testeable.