### PR TITLE
refactor: remove active interval when nothing to swap

### DIFF
--- a/contracts/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/DCAHub/DCAHubSwapHandler.sol
@@ -28,13 +28,18 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
         accumRatioBToA: _accumRatioMem.accumRatioBToA + _ratioBToA
       });
       SwapDelta memory _swapDeltaMem = _swapAmountDelta[_tokenA][_tokenB][_swapIntervalMask][_swapDataMem.performedSwaps + 2];
+      uint224 _nextAmountToSwapAToB = _swapDataMem.nextAmountToSwapAToB - _swapDeltaMem.swapDeltaAToB;
+      uint224 _nextAmountToSwapBToA = _swapDataMem.nextAmountToSwapBToA - _swapDeltaMem.swapDeltaBToA;
       _swapData[_tokenA][_tokenB][_swapIntervalMask] = SwapData({
         performedSwaps: _swapDataMem.performedSwaps + 1,
         lastSwappedAt: _timestamp,
-        nextAmountToSwapAToB: _swapDataMem.nextAmountToSwapAToB - _swapDeltaMem.swapDeltaAToB,
-        nextAmountToSwapBToA: _swapDataMem.nextAmountToSwapBToA - _swapDeltaMem.swapDeltaBToA
+        nextAmountToSwapAToB: _nextAmountToSwapAToB,
+        nextAmountToSwapBToA: _nextAmountToSwapBToA
       });
       delete _swapAmountDelta[_tokenA][_tokenB][_swapIntervalMask][_swapDataMem.performedSwaps + 2];
+      if (_nextAmountToSwapAToB == 0 && _nextAmountToSwapBToA == 0) {
+        activeSwapIntervals[_tokenA][_tokenB] &= ~_swapIntervalMask;
+      }
     } else {
       activeSwapIntervals[_tokenA][_tokenB] &= ~_swapIntervalMask;
     }

--- a/test/e2e/DCAHub/active-intervals.spec.ts
+++ b/test/e2e/DCAHub/active-intervals.spec.ts
@@ -21,7 +21,7 @@ import { SwapInterval } from 'js-lib/interval-utils';
 import { FakeContract, smock } from '@defi-wonderland/smock';
 import { snapshot } from '@test-utils/evm';
 
-contract.only('DCAHub', () => {
+contract('DCAHub', () => {
   let snapshotId: string;
   let governor: SignerWithAddress, john: SignerWithAddress;
   let tokenA: TokenContract, tokenB: TokenContract;

--- a/test/e2e/DCAHub/active-intervals.spec.ts
+++ b/test/e2e/DCAHub/active-intervals.spec.ts
@@ -84,7 +84,7 @@ contract('DCAHub', () => {
     expect(activeIntervals).to.equal('0x00');
   });
 
-  it('interval is continues as active when there are more swaps left to be executed', async () => {
+  it('interval continues to be active when there are more swaps left to be executed', async () => {
     await deposit({
       from: tokenA,
       to: tokenB,

--- a/test/e2e/DCAHub/active-intervals.spec.ts
+++ b/test/e2e/DCAHub/active-intervals.spec.ts
@@ -98,6 +98,35 @@ contract('DCAHub', () => {
     expect(activeIntervals).to.not.equal('0x00');
   });
 
+  it('interval can be reactivated when a new position is created', async () => {
+    await deposit({
+      from: tokenA,
+      to: tokenB,
+      owner: john,
+      rate: 10,
+      swaps: 1,
+      swapInterval: SwapInterval.ONE_DAY,
+    });
+    await flashSwap({ callee: DCAHubSwapCallee });
+    const activeIntervals = await DCAHub.activeSwapIntervals(tokenA.address, tokenB.address);
+    expect(activeIntervals).to.equal('0x00');
+
+    await evm.advanceTimeAndBlock(SwapInterval.ONE_DAY.seconds);
+    await deposit({
+      from: tokenA,
+      to: tokenB,
+      owner: john,
+      rate: 5,
+      swaps: 2,
+      swapInterval: SwapInterval.ONE_DAY,
+    });
+    const activeIntervals2 = await DCAHub.activeSwapIntervals(tokenA.address, tokenB.address);
+    expect(activeIntervals2).to.not.equal('0x00');
+    await flashSwap({ callee: DCAHubSwapCallee });
+    const activeIntervals3 = await DCAHub.activeSwapIntervals(tokenA.address, tokenB.address);
+    expect(activeIntervals3).to.not.equal('0x00');
+  });
+
   async function deposit({
     from,
     to,

--- a/test/e2e/DCAHub/active-intervals.spec.ts
+++ b/test/e2e/DCAHub/active-intervals.spec.ts
@@ -1,0 +1,133 @@
+import { expect } from 'chai';
+import { BigNumber, utils } from 'ethers';
+import { ethers } from 'hardhat';
+import {
+  DCAHub,
+  DCAHub__factory,
+  DCAHubSwapCalleeMock,
+  DCAHubSwapCalleeMock__factory,
+  DCAPermissionsManager,
+  DCAPermissionsManager__factory,
+  IPriceOracle,
+} from '@typechained';
+import { TransactionResponse } from '@ethersproject/abstract-provider';
+import { constants, erc20, evm } from '@test-utils';
+import { contract } from '@test-utils/bdd';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { TokenContract } from '@test-utils/erc20';
+import { readArgFromEventOrFail } from '@test-utils/event-utils';
+import { buildSwapInput } from 'js-lib/swap-utils';
+import { SwapInterval } from 'js-lib/interval-utils';
+import { FakeContract, smock } from '@defi-wonderland/smock';
+import { snapshot } from '@test-utils/evm';
+
+contract.only('DCAHub', () => {
+  let snapshotId: string;
+  let governor: SignerWithAddress, john: SignerWithAddress;
+  let tokenA: TokenContract, tokenB: TokenContract;
+  let DCAHubFactory: DCAHub__factory, DCAHub: DCAHub;
+  let priceOracle: FakeContract<IPriceOracle>;
+  let DCAHubSwapCalleeFactory: DCAHubSwapCalleeMock__factory, DCAHubSwapCallee: DCAHubSwapCalleeMock;
+  let DCAPermissionsManagerFactory: DCAPermissionsManager__factory, DCAPermissionsManager: DCAPermissionsManager;
+
+  before('Setup accounts and contracts', async () => {
+    [governor, john] = await ethers.getSigners();
+    DCAHubFactory = await ethers.getContractFactory('contracts/DCAHub/DCAHub.sol:DCAHub');
+    DCAHubSwapCalleeFactory = await ethers.getContractFactory('contracts/mocks/DCAHubSwapCallee.sol:DCAHubSwapCalleeMock');
+    DCAPermissionsManagerFactory = await ethers.getContractFactory(
+      'contracts/DCAPermissionsManager/DCAPermissionsManager.sol:DCAPermissionsManager'
+    );
+
+    tokenA = await erc20.deploy({
+      name: 'tokenA',
+      symbol: 'TKNA',
+      decimals: 12,
+    });
+    tokenB = await erc20.deploy({
+      name: 'tokenB',
+      symbol: 'TKNB',
+      decimals: 16,
+    });
+
+    priceOracle = await smock.fake('IPriceOracle');
+    DCAPermissionsManager = await DCAPermissionsManagerFactory.deploy(constants.NOT_ZERO_ADDRESS, constants.NOT_ZERO_ADDRESS);
+
+    DCAHub = await DCAHubFactory.deploy(governor.address, governor.address, priceOracle.address, DCAPermissionsManager.address);
+    await DCAPermissionsManager.setHub(DCAHub.address);
+    await DCAHub.setAllowedTokens([tokenA.address, tokenB.address], [true, true]);
+
+    DCAHubSwapCallee = await DCAHubSwapCalleeFactory.deploy();
+    await DCAHubSwapCallee.avoidRewardCheck();
+    await tokenA.mint(DCAHubSwapCallee.address, utils.parseEther('6969696969420'));
+    await tokenB.mint(DCAHubSwapCallee.address, utils.parseEther('6969696969420'));
+
+    priceOracle.quote.returns(utils.parseEther('1'));
+
+    snapshotId = await snapshot.take();
+  });
+
+  beforeEach(async () => {
+    await snapshot.revert(snapshotId);
+  });
+
+  it('interval is set as inactive when there are no more swaps being executed', async () => {
+    await deposit({
+      from: tokenA,
+      to: tokenB,
+      owner: john,
+      rate: 10,
+      swaps: 1,
+      swapInterval: SwapInterval.ONE_DAY,
+    });
+    await flashSwap({ callee: DCAHubSwapCallee });
+    const activeIntervals = await DCAHub.activeSwapIntervals(tokenA.address, tokenB.address);
+    expect(activeIntervals).to.equal('0x00');
+  });
+
+  it('interval is continues as active when there are more swaps left to be executed', async () => {
+    await deposit({
+      from: tokenA,
+      to: tokenB,
+      owner: john,
+      rate: 10,
+      swaps: 2,
+      swapInterval: SwapInterval.ONE_DAY,
+    });
+    await flashSwap({ callee: DCAHubSwapCallee });
+    const activeIntervals = await DCAHub.activeSwapIntervals(tokenA.address, tokenB.address);
+    expect(activeIntervals).to.not.equal('0x00');
+  });
+
+  async function deposit({
+    from,
+    to,
+    owner,
+    rate,
+    swapInterval,
+    swaps,
+  }: {
+    from: TokenContract;
+    to: TokenContract;
+    owner: SignerWithAddress;
+    rate: number;
+    swapInterval: SwapInterval;
+    swaps: number;
+  }): Promise<BigNumber> {
+    const amount = from.asUnits(rate).mul(swaps);
+    await from.mint(owner.address, amount);
+    await from.connect(owner).approve(DCAHub.address, amount);
+    const response: TransactionResponse = await DCAHub.connect(owner)[
+      'deposit(address,address,uint256,uint32,uint32,address,(address,uint8[])[])'
+    ](from.address, to.address, amount, swaps, swapInterval.seconds, owner.address, []);
+    return await readArgFromEventOrFail<BigNumber>(response, 'Deposited', 'positionId');
+  }
+
+  async function flashSwap({ callee }: { callee: HasAddress }) {
+    const { tokens, pairIndexes, borrow } = buildSwapInput([{ tokenA: tokenA.address, tokenB: tokenB.address }], []);
+    await DCAHub.swap(tokens, pairIndexes, callee.address, callee.address, borrow, ethers.utils.randomBytes(5));
+  }
+
+  type HasAddress = {
+    readonly address: string;
+  };
+});

--- a/test/e2e/DCAHub/happy-path.spec.ts
+++ b/test/e2e/DCAHub/happy-path.spec.ts
@@ -21,7 +21,7 @@ import { SwapInterval } from 'js-lib/interval-utils';
 import { FakeContract, smock } from '@defi-wonderland/smock';
 import { Permission } from 'js-lib/types';
 
-contract('DCAHub', () => {
+contract.only('DCAHub', () => {
   describe('Full e2e test', () => {
     let governor: SignerWithAddress, john: SignerWithAddress;
     let lucy: SignerWithAddress, sarah: SignerWithAddress;
@@ -254,7 +254,7 @@ contract('DCAHub', () => {
       setSwapRatio(swapRatioBC2);
       await evm.advanceTimeAndBlock(SwapInterval.ONE_HOUR.seconds);
 
-      await assertIntervalsToSwapNowAre(SwapInterval.FIFTEEN_MINUTES, SwapInterval.ONE_HOUR);
+      await assertIntervalsToSwapNowAre(SwapInterval.FIFTEEN_MINUTES);
       await assertAmountsToSwapAre({ tokenA: 545, tokenB: 200, tokenC: 0 });
 
       await flashSwap({ callee: DCAHubSwapCallee });
@@ -364,15 +364,12 @@ contract('DCAHub', () => {
 
     let ratios: Map<string, (amountIn: BigNumber) => BigNumber> = new Map();
     function setSwapRatio({ token0, token1, ratio }: SwapRatio) {
-      if (token0.address < token1.address) {
-        ratios.set(`${token1.address}${token0.address}`, (amountIn) =>
-          amountIn.mul(token0.asUnits(ratio.token0 / ratio.token1)).div(token1.magnitude)
-        );
-      } else {
-        ratios.set(`${token0.address}${token1.address}`, (amountIn) =>
-          amountIn.mul(token1.asUnits(ratio.token1 / ratio.token0)).div(token0.magnitude)
-        );
-      }
+      ratios.set(`${token1.address}${token0.address}`, (amountIn) =>
+        amountIn.mul(token0.asUnits(ratio.token0 / ratio.token1)).div(token1.magnitude)
+      );
+      ratios.set(`${token0.address}${token1.address}`, (amountIn) =>
+        amountIn.mul(token1.asUnits(ratio.token1 / ratio.token0)).div(token0.magnitude)
+      );
       priceOracle.quote.returns(({ _amountIn, _tokenIn, _tokenOut }: { _tokenIn: string; _tokenOut: string; _amountIn: BigNumber }) =>
         ratios.get(`${_tokenIn}${_tokenOut}`)!(_amountIn)
       );

--- a/test/e2e/DCAHub/happy-path.spec.ts
+++ b/test/e2e/DCAHub/happy-path.spec.ts
@@ -21,7 +21,7 @@ import { SwapInterval } from 'js-lib/interval-utils';
 import { FakeContract, smock } from '@defi-wonderland/smock';
 import { Permission } from 'js-lib/types';
 
-contract.only('DCAHub', () => {
+contract('DCAHub', () => {
   describe('Full e2e test', () => {
     let governor: SignerWithAddress, john: SignerWithAddress;
     let lucy: SignerWithAddress, sarah: SignerWithAddress;

--- a/test/e2e/DCAHub/max-rate.spec.ts
+++ b/test/e2e/DCAHub/max-rate.spec.ts
@@ -56,7 +56,7 @@ contract('DCAHub', () => {
         decimals: 16,
       });
       priceOracle = await smock.fake('IPriceOracle');
-      priceOracle.quote.returns(tokenA.address < tokenB.address ? tokenA.asUnits(1) : tokenB.asUnits(1));
+      priceOracle.quote.returns(tokenA.address.toLowerCase() < tokenB.address.toLowerCase() ? tokenA.asUnits(1) : tokenB.asUnits(1));
       DCAPermissionsManager = await DCAPermissionsManagerFactory.deploy(constants.NOT_ZERO_ADDRESS, constants.NOT_ZERO_ADDRESS);
       DCAHub = await DCAHubFactory.deploy(governor.address, governor.address, priceOracle.address, DCAPermissionsManager.address);
       await DCAPermissionsManager.setHub(DCAHub.address);


### PR DESCRIPTION
Before this change, it could happen that after there was nothing left to swap, an interval would remain active. This wasn't a big problem, but it was unnecessary and it could slightly increase gas costs. Now, we check that if there is nothing left to swap, we will simply remove said interval from the active list

It's important to notice that it could still happen that a user terminates their on-going position, and the interval will continue to be set as active, even if there is nothing left to swap. We do this because we don't want to increase the costs of reducing a position or terminating it