### PR TITLE
refactor: show different svg data

### DIFF
--- a/contracts/DCATokenDescriptor/DCATokenDescriptor.sol
+++ b/contracts/DCATokenDescriptor/DCATokenDescriptor.sol
@@ -24,7 +24,7 @@ contract DCATokenDescriptor is IDCATokenDescriptor {
           toSymbol: _userPosition.to.symbol(),
           swapInterval: intervalToDescription(_userPosition.swapInterval),
           swapsExecuted: _userPosition.swapsExecuted,
-          swapped: _userPosition.swapped,
+          toWithdraw: _userPosition.swapped,
           swapsLeft: _userPosition.swapsLeft,
           remaining: _userPosition.remaining,
           rate: _userPosition.rate

--- a/contracts/libraries/NFTDescriptor.sol
+++ b/contracts/libraries/NFTDescriptor.sol
@@ -22,7 +22,7 @@ library NFTDescriptor {
     string swapInterval;
     uint32 swapsExecuted;
     uint32 swapsLeft;
-    uint256 swapped;
+    uint256 toWithdraw;
     uint256 remaining;
     uint160 rate;
   }
@@ -233,18 +233,20 @@ library NFTDescriptor {
       interval: _params.swapInterval,
       swapsExecuted: _params.swapsExecuted,
       swapsLeft: _params.swapsLeft,
-      swapped: string(abi.encodePacked(fixedPointToDecimalString(_params.swapped, _params.toDecimals), ' ', _toSymbol)),
-      averagePrice: string(
-        abi.encodePacked(
-          fixedPointToDecimalString(_params.swapsExecuted > 0 ? _params.swapped / _params.swapsExecuted : 0, _params.toDecimals),
-          ' ',
-          _toSymbol
-        )
-      ),
-      remaining: string(abi.encodePacked(fixedPointToDecimalString(_params.remaining, _params.fromDecimals), ' ', _fromSymbol)),
-      rate: string(abi.encodePacked(fixedPointToDecimalString(_params.rate, _params.fromDecimals), ' ', _fromSymbol))
+      toWithdraw: _amountToReadable(_params.toWithdraw, _params.toDecimals, _toSymbol),
+      swapped: _amountToReadable(_params.rate * _params.swapsExecuted, _params.fromDecimals, _fromSymbol),
+      remaining: _amountToReadable(_params.remaining, _params.fromDecimals, _fromSymbol),
+      rate: _amountToReadable(_params.rate, _params.fromDecimals, _fromSymbol)
     });
 
     return NFTSVG.generateSVG(_svgParams);
+  }
+
+  function _amountToReadable(
+    uint256 _amount,
+    uint8 _decimals,
+    string memory _symbol
+  ) internal pure returns (string memory) {
+    return string(abi.encodePacked(fixedPointToDecimalString(_amount, _decimals), ' ', _symbol));
   }
 }

--- a/contracts/libraries/NFTDescriptor.sol
+++ b/contracts/libraries/NFTDescriptor.sol
@@ -246,7 +246,7 @@ library NFTDescriptor {
     uint256 _amount,
     uint8 _decimals,
     string memory _symbol
-  ) internal pure returns (string memory) {
+  ) private pure returns (string memory) {
     return string(abi.encodePacked(fixedPointToDecimalString(_amount, _decimals), ' ', _symbol));
   }
 }

--- a/contracts/libraries/NFTSVG.sol
+++ b/contracts/libraries/NFTSVG.sol
@@ -19,7 +19,7 @@ library NFTSVG {
     uint32 swapsLeft;
     uint256 tokenId;
     string swapped;
-    string averagePrice;
+    string toWithdraw;
     string remaining;
     string rate;
   }
@@ -36,7 +36,7 @@ library NFTSVG {
           _generateSVGDefs(),
           _generateSVGBackground(),
           _generateSVGCardMantle(params.fromSymbol, params.toSymbol, params.interval),
-          _generateSVGPositionData(params.tokenId, params.swapped, params.averagePrice, params.remaining, params.rate),
+          _generateSVGPositionData(params.tokenId, params.toWithdraw, params.swapped, params.remaining, params.rate),
           _generateSVGBorderText(params.fromToken, params.toToken, params.fromSymbol, params.toSymbol),
           _generateSVGLinesAndMainLogo(_percentage),
           _generageSVGProgressArea(params.swapsExecuted, params.swapsLeft),
@@ -128,8 +128,8 @@ library NFTSVG {
 
   function _generateSVGPositionData(
     uint256 _tokenId,
+    string memory _toWithdraw,
     string memory _swapped,
-    string memory _averagePrice,
     string memory _remaining,
     string memory _rate
   ) private pure returns (string memory svg) {
@@ -137,10 +137,10 @@ library NFTSVG {
       abi.encodePacked(
         '<text transform="matrix(1 0 0 1 68.3549 775.8853)"><tspan x="0" y="0" class="st36 st38 st44">Id: ',
         _tokenId.toString(),
-        '</tspan><tspan x="0" y="52.37" class="st36 st38 st44">Swapped*: ',
+        '</tspan><tspan x="0" y="52.37" class="st36 st38 st44">To Withdraw: ',
+        _toWithdraw,
+        '</tspan><tspan x="0" y="104.73" class="st36 st38 st44">Swapped*: ',
         _swapped,
-        '</tspan><tspan x="0" y="104.73" class="st36 st38 st44">Avg Price: ',
-        _averagePrice,
         '</tspan><tspan x="0" y="157.1" class="st36 st38 st44">Remaining: ',
         _remaining,
         '</tspan><tspan x="0" y="209.47" class="st36 st38 st44">Rate: ',

--- a/test/e2e/DCATokenDescriptor/token-descriptor-is-valid.spec.ts
+++ b/test/e2e/DCATokenDescriptor/token-descriptor-is-valid.spec.ts
@@ -85,32 +85,43 @@ contract('DCATokenDescriptor', () => {
       []
     );
     const tokenId = await readArgFromEventOrFail<BigNumber>(response, 'Deposited', 'positionId');
+    const result1 = await DCAPermissionsManager.tokenURI(tokenId);
+    const { name: name1, description: description1, image: image1 } = extractJSONFromURI(result1);
 
     // Execute one swap
     await swap();
 
     // Get token uri
-    const result1 = await DCAPermissionsManager.tokenURI(tokenId);
-    const { name: name1, description: description1, image: image1 } = extractJSONFromURI(result1);
+    const result2 = await DCAPermissionsManager.tokenURI(tokenId);
+    const { name: name2, description: description2, image: image2 } = extractJSONFromURI(result2);
+
+    // Execute the last swap and withdraw
+    await evm.advanceTimeAndBlock(swapInterval);
+    await swap();
+
+    const result3 = await DCAPermissionsManager.tokenURI(tokenId);
+    const { name: name3, description: description3, image: image3 } = extractJSONFromURI(result3);
+
+    await DCAHub.withdrawSwapped(tokenId, wallet.generateRandomAddress());
+
+    // Get token uri
+    const result4 = await DCAPermissionsManager.tokenURI(tokenId);
+    const { name: name4, description: description4, image: image4 } = extractJSONFromURI(result4);
 
     expect(name1).to.equal('Mean Finance DCA - Daily - TKNB ➔ TKNA');
     expect(description1).to.equal(
       `This NFT represents a DCA position in Mean Finance, where TKNB will be swapped for TKNA. The owner of this NFT can modify or redeem the position.\n\nTKNB Address: ${tokenB.address.toLowerCase()}\nTKNA Address: ${tokenA.address.toLowerCase()}\nSwap interval: Daily\nToken ID: 1\n\n⚠️ DISCLAIMER: Due diligence is imperative when assessing this NFT. Make sure token addresses match the expected tokens, as token symbols may be imitated.`
     );
-    expect(isValidSvgImage(image1)).to.be.true;
-
-    // Execute the last swap and withdraw
-    await evm.advanceTimeAndBlock(swapInterval);
-    await swap();
-    await DCAHub.withdrawSwapped(tokenId, wallet.generateRandomAddress());
-
-    // Get token uri
-    const result2 = await DCAPermissionsManager.tokenURI(tokenId);
-    const { name: name2, description: description2, image: image2 } = extractJSONFromURI(result2);
-
     expect(name2).to.equal(name1);
+    expect(name3).to.equal(name1);
+    expect(name4).to.equal(name1);
     expect(description2).to.equal(description1);
+    expect(description3).to.equal(description1);
+    expect(description4).to.equal(description1);
+    expect(isValidSvgImage(image1)).to.be.true;
     expect(isValidSvgImage(image2)).to.be.true;
+    expect(isValidSvgImage(image3)).to.be.true;
+    expect(isValidSvgImage(image4)).to.be.true;
   });
 
   async function swap() {


### PR DESCRIPTION
Before this change, we were showing data in the SVG that was invalid. If the position had been modified, then the swapped property would not make sense. Now, we are making two changes:
1. Instead of showing the swapped for the `to` token, we are showing it for the `from` token (this we can calculate corrctly)
2. We removed `Avg Price` and instead we are showing how much is available to withdraw
This is how it looks:
**Before any swap is executed**
![Screen Shot 2022-07-15 at 2 44 50 PM](https://user-images.githubusercontent.com/15222168/179281512-1f28778a-4cf3-446f-ad44-15bc096a28d6.png)
**After one swap**
![Screen Shot 2022-07-15 at 2 48 05 PM](https://user-images.githubusercontent.com/15222168/179282001-2a58ad62-9216-47a3-a11d-3326b7898c9f.png)
**After all swap**
![Screen Shot 2022-07-15 at 2 48 21 PM](https://user-images.githubusercontent.com/15222168/179282037-0b79f157-5e62-4011-ac42-a0b927b27d7b.png)
**After withdraw**
![Screen Shot 2022-07-15 at 2 48 40 PM](https://user-images.githubusercontent.com/15222168/179282109-edf65b56-ac9d-467b-bafd-dd9165d41043.png)

