### PR TITLE
feat: add privileged availability

### DIFF
--- a/contracts/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/DCAHub/DCAHubSwapHandler.sol
@@ -150,9 +150,6 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
       _pairInSwap.tokenA = _tokens[indexTokenA];
       _pairInSwap.tokenB = _tokens[indexTokenB];
 
-      uint256 _magnitudeA = tokenMagnitude[_pairInSwap.tokenA];
-      uint256 _magnitudeB = tokenMagnitude[_pairInSwap.tokenB];
-
       uint256 _amountToSwapTokenA;
       uint256 _amountToSwapTokenB;
 
@@ -164,6 +161,9 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
 
       _total[indexTokenA] += _amountToSwapTokenA;
       _total[indexTokenB] += _amountToSwapTokenB;
+
+      uint256 _magnitudeA = tokenMagnitude[_pairInSwap.tokenA];
+      uint256 _magnitudeB = tokenMagnitude[_pairInSwap.tokenB];
 
       (_pairInSwap.ratioAToB, _pairInSwap.ratioBToA) = _calculateRatio(
         _pairInSwap.tokenA,

--- a/contracts/interfaces/IDCAHub.sol
+++ b/contracts/interfaces/IDCAHub.sol
@@ -473,9 +473,15 @@ interface IDCAHubSwapHandler {
    *      - With InvalidPairs if pairs are not sorted (first by indexTokenA and then indexTokenB), or if indexTokenA >= indexTokenB for any pair
    * @param tokens The tokens involved in the next swap
    * @param pairs The pairs that you want to swap. Each element of the list points to the index of the token in the tokens array
+   * @param calculatePrivilegedAvailability Some accounts get privileged availability and can execute swaps before others. This flag provides
+   *        the possibility to calculate the next swap information for privileged and non-privileged accounts
    * @return swapInformation The information about the next swap
    */
-  function getNextSwapInfo(address[] calldata tokens, PairIndexes[] calldata pairs) external view returns (SwapInfo memory swapInformation);
+  function getNextSwapInfo(
+    address[] calldata tokens,
+    PairIndexes[] calldata pairs,
+    bool calculatePrivilegedAvailability
+  ) external view returns (SwapInfo memory swapInformation);
 
   /**
    * @notice Executes a flash swap

--- a/contracts/mocks/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/mocks/DCAHub/DCAHubSwapHandler.sol
@@ -50,7 +50,11 @@ contract DCAHubSwapHandlerMock is DCAHubSwapHandler, DCAHubConfigHandlerMock {
     _blockTimestamp = (_customTimestamp > 0) ? _customTimestamp : super._getTimestamp();
   }
 
-  function getTotalAmountsToSwap(address _tokenA, address _tokenB)
+  function getTotalAmountsToSwap(
+    address _tokenA,
+    address _tokenB,
+    bool _calculatePrivilegedAvailability
+  )
     external
     view
     returns (
@@ -59,10 +63,14 @@ contract DCAHubSwapHandlerMock is DCAHubSwapHandler, DCAHubConfigHandlerMock {
       bytes1
     )
   {
-    return _getTotalAmountsToSwap(_tokenA, _tokenB);
+    return _getTotalAmountsToSwap(_tokenA, _tokenB, _calculatePrivilegedAvailability);
   }
 
-  function _getTotalAmountsToSwap(address _tokenA, address _tokenB)
+  function _getTotalAmountsToSwap(
+    address _tokenA,
+    address _tokenB,
+    bool _calculatePrivilegedAvailability
+  )
     internal
     view
     override
@@ -74,18 +82,22 @@ contract DCAHubSwapHandlerMock is DCAHubSwapHandler, DCAHubConfigHandlerMock {
   {
     TotalAmountsToSwap memory _amounts = _totalAmountsToSwap[_tokenA][_tokenB];
     if (_amounts.amountTokenA == 0 && _amounts.amountTokenB == 0) {
-      return super._getTotalAmountsToSwap(_tokenA, _tokenB);
+      return super._getTotalAmountsToSwap(_tokenA, _tokenB, _calculatePrivilegedAvailability);
     }
     _totalAmountTokenA = _amounts.amountTokenA;
     _totalAmountTokenB = _amounts.amountTokenB;
     _affectedIntervals = _amounts.intervalsInSwap;
   }
 
-  function getNextSwapInfo(address[] calldata _tokens, PairIndexes[] calldata _pairs) public view override returns (SwapInfo memory) {
+  function getNextSwapInfo(
+    address[] calldata _tokens,
+    PairIndexes[] calldata _pairs,
+    bool _calculatePrivilegedAvailability
+  ) public view override returns (SwapInfo memory) {
     if (_swapInformation.tokens.length > 0) {
       return _swapInformation;
     } else {
-      return super.getNextSwapInfo(_tokens, _pairs);
+      return super.getNextSwapInfo(_tokens, _pairs, _calculatePrivilegedAvailability);
     }
   }
 

--- a/test/e2e/DCAHub/happy-path.spec.ts
+++ b/test/e2e/DCAHub/happy-path.spec.ts
@@ -417,7 +417,7 @@ contract('DCAHub', () => {
         ],
         []
       );
-      return DCAHub.getNextSwapInfo(tokens, pairIndexes);
+      return DCAHub.getNextSwapInfo(tokens, pairIndexes, true);
     }
 
     async function reducePosition(position: UserPositionDefinition, args: { newSwaps: number; amount: number }) {

--- a/test/e2e/DCAHub/max-rate.spec.ts
+++ b/test/e2e/DCAHub/max-rate.spec.ts
@@ -99,7 +99,7 @@ contract('DCAHub', () => {
 
     async function assertThereIsNothingElseToSwap() {
       const { tokens, pairIndexes } = buildGetNextSwapInfoInput([{ tokenA: tokenA.address, tokenB: tokenB.address }], []);
-      const { pairs } = await DCAHub.getNextSwapInfo(tokens, pairIndexes);
+      const { pairs } = await DCAHub.getNextSwapInfo(tokens, pairIndexes, true);
       expect(pairs[0].intervalsInSwap).to.equal('0x00');
     }
 

--- a/test/unit/DCAHub/dca-hub-swap-handler.spec.ts
+++ b/test/unit/DCAHub/dca-hub-swap-handler.spec.ts
@@ -606,7 +606,7 @@ contract('DCAHubSwapHandler', () => {
           await behaviours.txShouldRevertWithMessage({
             contract: DCAHubSwapHandler,
             func: 'getNextSwapInfo',
-            args: [tokens.map((token) => token().address), pairs],
+            args: [tokens.map((token) => token().address), pairs, true],
             message: error,
           });
         });


### PR DESCRIPTION
We are now changing how the DCAHub works. The idea is that addresses with privileged access are able to execute swaps in the first third of the time interval. Everyone else will have to wait until that third of the time interval is finished.

The idea is that `getNextSwapInfo` will return different values for privileged accounts