### PR TITLE
refactor: swap privilege based on role

### DIFF
--- a/contracts/DCAHub/DCAHubConfigHandler.sol
+++ b/contracts/DCAHub/DCAHubConfigHandler.sol
@@ -13,8 +13,9 @@ abstract contract DCAHubConfigHandler is DCAHubParameters, AccessControl, Pausab
   // solhint-disable var-name-mixedcase
   bytes32 public IMMEDIATE_ROLE = keccak256('IMMEDIATE_ROLE');
   bytes32 public TIME_LOCKED_ROLE = keccak256('TIME_LOCKED_ROLE');
-  bytes32 public PLATFORM_WITHDRAW_ROLE = keccak256('PLATFORM_WITHDRAW_ROLE');
   // solhint-enable var-name-mixedcase
+  bytes32 public constant PLATFORM_WITHDRAW_ROLE = keccak256('PLATFORM_WITHDRAW_ROLE');
+  bytes32 public constant PRIVILEGED_SWAPPER_ROLE = keccak256('PRIVILEGED_SWAPPER_ROLE');
   /// @inheritdoc IDCAHubConfigHandler
   uint32 public constant MAX_FEE = 100000; // 10%
   /// @inheritdoc IDCAHubConfigHandler
@@ -42,6 +43,7 @@ abstract contract DCAHubConfigHandler is DCAHubParameters, AccessControl, Pausab
     _setupRole(IMMEDIATE_ROLE, _immediateGovernor);
     _setupRole(TIME_LOCKED_ROLE, _timeLockedGovernor);
     _setRoleAdmin(PLATFORM_WITHDRAW_ROLE, IMMEDIATE_ROLE);
+    _setRoleAdmin(PRIVILEGED_SWAPPER_ROLE, IMMEDIATE_ROLE);
     // We set each role as its own admin, so they can assign new addresses with the same role
     _setRoleAdmin(IMMEDIATE_ROLE, IMMEDIATE_ROLE);
     _setRoleAdmin(TIME_LOCKED_ROLE, TIME_LOCKED_ROLE);

--- a/contracts/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/DCAHub/DCAHubSwapHandler.sol
@@ -229,8 +229,7 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
     uint32 _swapFee = swapFee;
 
     {
-      // TODO: Determinate if privileged availability based on msg.sender
-      _swapInformation = getNextSwapInfo(_tokens, _pairsToSwap, true);
+      _swapInformation = getNextSwapInfo(_tokens, _pairsToSwap, hasRole(PRIVILEGED_SWAPPER_ROLE, msg.sender));
 
       uint32 _timestamp = _getTimestamp();
       bool _executedAPair;

--- a/test/e2e/DCAHub/active-intervals.spec.ts
+++ b/test/e2e/DCAHub/active-intervals.spec.ts
@@ -111,7 +111,7 @@ contract('DCAHub', () => {
     const activeIntervals = await DCAHub.activeSwapIntervals(tokenA.address, tokenB.address);
     expect(activeIntervals).to.equal('0x00');
 
-    await evm.advanceTimeAndBlock(SwapInterval.ONE_DAY.seconds);
+    await evm.advanceTimeAndBlock(SwapInterval.ONE_DAY.seconds * 2);
     await deposit({
       from: tokenA,
       to: tokenB,

--- a/test/e2e/DCAHub/allowed-tokens.spec.ts
+++ b/test/e2e/DCAHub/allowed-tokens.spec.ts
@@ -161,7 +161,7 @@ contract('DCAHub', () => {
     await DCAHub.connect(john).withdrawSwapped(positionId, john.address);
     expect(await tokenB.balanceOf(john.address)).to.be.gt(previousBalance);
     const { tokens, pairIndexes, borrow } = buildSwapInput([{ tokenA: tokenA.address, tokenB: tokenB.address }], []);
-    await evm.advanceTimeAndBlock(SwapInterval.ONE_MINUTE.seconds);
+    await evm.advanceTimeAndBlock(SwapInterval.FIVE_MINUTES.seconds);
     await expect(
       DCAHub.swap(tokens, pairIndexes, DCAHubSwapCallee.address, DCAHubSwapCallee.address, borrow, ethers.utils.randomBytes(5))
     ).to.be.revertedWith('UnallowedToken');

--- a/test/e2e/DCAHub/happy-path.spec.ts
+++ b/test/e2e/DCAHub/happy-path.spec.ts
@@ -69,6 +69,7 @@ contract('DCAHub', () => {
       await DCAHub.setAllowedTokens([tokenA.address, tokenB.address, tokenC.address], [true, true, true]);
       await DCAHub.addSwapIntervalsToAllowedList([SwapInterval.FIFTEEN_MINUTES.seconds, SwapInterval.ONE_HOUR.seconds]);
       await DCAHub.setPlatformFeeRatio(5000);
+      await DCAHub.connect(governor).grantRole(await DCAHub.PRIVILEGED_SWAPPER_ROLE(), governor.address);
       DCAHubSwapCallee = await DCAHubSwapCalleeFactory.deploy();
       await DCAHubSwapCallee.setInitialBalances(
         [tokenA.address, tokenB.address, tokenC.address],

--- a/test/e2e/DCAHub/max-rate.spec.ts
+++ b/test/e2e/DCAHub/max-rate.spec.ts
@@ -127,7 +127,7 @@ contract('DCAHub', () => {
       const { tokens, pairIndexes, borrow } = buildSwapInput([{ tokenA: tokenA.address, tokenB: tokenB.address }], []);
       for (let i = 0; i < times; i++) {
         await DCAHub.swap(tokens, pairIndexes, DCAHubSwapCallee.address, DCAHubSwapCallee.address, borrow, ethers.utils.randomBytes(5));
-        await evm.advanceTimeAndBlock(SwapInterval.ONE_DAY.seconds);
+        await evm.advanceTimeAndBlock(SwapInterval.ONE_DAY.seconds * 2);
       }
     }
   });

--- a/test/e2e/DCAHub/position-interaction.spec.ts
+++ b/test/e2e/DCAHub/position-interaction.spec.ts
@@ -212,7 +212,7 @@ contract('DCAHub', () => {
           [await tokenA.balanceOf(DCAHubSwapCallee.address), await tokenB.balanceOf(DCAHubSwapCallee.address)]
         );
         await DCAHub.swap(tokens, pairIndexes, DCAHubSwapCallee.address, DCAHubSwapCallee.address, borrow, ethers.utils.randomBytes(5));
-        await evm.advanceTimeAndBlock(SwapInterval.ONE_DAY.seconds);
+        await evm.advanceTimeAndBlock(SwapInterval.ONE_DAY.seconds * 2);
       }
     }
   });

--- a/test/e2e/DCAHub/precision-breaker.spec.ts
+++ b/test/e2e/DCAHub/precision-breaker.spec.ts
@@ -88,22 +88,22 @@ contract('DCAHub', () => {
           []
         );
 
-        await evm.advanceTimeAndBlock(SwapInterval.ONE_HOUR.seconds);
+        await evm.advanceTimeAndBlock(SwapInterval.ONE_DAY.seconds);
         setPriceOracle('2246');
         await flashSwap({ callee: DCAHubSwapCallee });
-        await evm.advanceTimeAndBlock(SwapInterval.ONE_HOUR.seconds);
+        await evm.advanceTimeAndBlock(SwapInterval.ONE_DAY.seconds);
         setPriceOracle('2209');
         await flashSwap({ callee: DCAHubSwapCallee });
-        await evm.advanceTimeAndBlock(SwapInterval.ONE_HOUR.seconds);
+        await evm.advanceTimeAndBlock(SwapInterval.ONE_DAY.seconds);
         setPriceOracle('2190');
         await flashSwap({ callee: DCAHubSwapCallee });
 
         await DCAHub.connect(alice).withdrawSwapped(1, wallet.generateRandomAddress());
 
-        await evm.advanceTimeAndBlock(SwapInterval.ONE_HOUR.seconds);
+        await evm.advanceTimeAndBlock(SwapInterval.ONE_DAY.seconds);
         setPriceOracle('2175');
         await flashSwap({ callee: DCAHubSwapCallee });
-        await evm.advanceTimeAndBlock(SwapInterval.ONE_HOUR.seconds);
+        await evm.advanceTimeAndBlock(SwapInterval.ONE_DAY.seconds);
         setPriceOracle('2216');
         await flashSwap({ callee: DCAHubSwapCallee });
 

--- a/test/integration/DCAHubPositionDescriptor/dca-hub-position-descriptor.spec.ts
+++ b/test/integration/DCAHubPositionDescriptor/dca-hub-position-descriptor.spec.ts
@@ -58,6 +58,7 @@ describe('DCAHubPositionDescriptor', () => {
     const factory: DCAHubSwapCalleeMock__factory = await ethers.getContractFactory('contracts/mocks/DCAHubSwapCallee.sol:DCAHubSwapCalleeMock');
     DCAHubSwapCallee = await factory.deploy();
     await DCAHubSwapCallee.avoidRewardCheck();
+    await DCAHub.connect(governor).grantRole(await DCAHub.PRIVILEGED_SWAPPER_ROLE(), joe.address);
 
     await distributeTokensToUsers();
     await WETH.connect(joe).approve(DCAHub.address, constants.MaxUint256);

--- a/test/unit/DCAHub/dca-hub-config-handler.spec.ts
+++ b/test/unit/DCAHub/dca-hub-config-handler.spec.ts
@@ -83,6 +83,10 @@ contract('DCAHubConfigHandler', () => {
         const adminRole = await deployedContract.getRoleAdmin(await deployedContract.PLATFORM_WITHDRAW_ROLE());
         expect(adminRole).to.equal(immediateRole);
       });
+      then(`immediate role is privileged swappers's admin`, async () => {
+        const adminRole = await deployedContract.getRoleAdmin(await deployedContract.PRIVILEGED_SWAPPER_ROLE());
+        expect(adminRole).to.equal(immediateRole);
+      });
       then(`bigger intervals start allowed`, async () => {
         const allowedIntervals = [SwapInterval.ONE_WEEK, SwapInterval.ONE_DAY, SwapInterval.FOUR_HOURS, SwapInterval.ONE_HOUR];
         for (const interval of allowedIntervals) {


### PR DESCRIPTION
We are now adding a new role called `PRIVILEGED_SWAPPER_ROLE`. Accounts with the given role will be able to execute swaps during the first 1/3 of the time interval. All other accounts will have to wait 