### PR TITLE
refactor: take oracle data

### DIFF
--- a/contracts/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/DCAHub/DCAHubSwapHandler.sol
@@ -118,7 +118,7 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
     address _tokenA,
     address _tokenB,
     ITokenPriceOracle _oracle,
-    bytes calldata _data
+    bytes calldata _oracleData
   )
     internal
     view
@@ -131,7 +131,7 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
   {
     _magnitudes.magnitudeA = tokenMagnitude[_tokenA];
     _magnitudes.magnitudeB = tokenMagnitude[_tokenB];
-    _ratioBToA = _oracle.quote(_tokenB, _magnitudes.magnitudeB, _tokenA, _data);
+    _ratioBToA = _oracle.quote(_tokenB, _magnitudes.magnitudeB, _tokenA, _oracleData);
     _ratioAToB = (_magnitudes.magnitudeB * _magnitudes.magnitudeA) / _ratioBToA;
   }
 

--- a/contracts/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/DCAHub/DCAHubSwapHandler.sol
@@ -175,7 +175,7 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
       _total[indexTokenA] += _pairInSwap.totalAmountToSwapTokenA;
       _total[indexTokenB] += _pairInSwap.totalAmountToSwapTokenB;
 
-      // Note: it would be better to calculate the magnitudes here instead of inside `_calculateRatio`, but it throws a stack to deep error
+      // Note: it would be better to calculate the magnitudes here instead of inside `_calculateRatio`, but it throws a "stack to deep" error
       PairMagnitudes memory _magnitudes;
       (_pairInSwap.ratioAToB, _pairInSwap.ratioBToA, _magnitudes) = _calculateRatio(
         _pairInSwap.tokenA,

--- a/contracts/interfaces/IDCAHub.sol
+++ b/contracts/interfaces/IDCAHub.sol
@@ -426,6 +426,8 @@ interface IDCAHubSwapHandler {
     address tokenA;
     // The address of the other token
     address tokenB;
+    uint256 totalAmountToSwapTokenA;
+    uint256 totalAmountToSwapTokenB;
     // How much is 1 unit of token A when converted to B
     uint256 ratioAToB;
     // How much is 1 unit of token B when converted to A
@@ -475,12 +477,14 @@ interface IDCAHubSwapHandler {
    * @param pairs The pairs that you want to swap. Each element of the list points to the index of the token in the tokens array
    * @param calculatePrivilegedAvailability Some accounts get privileged availability and can execute swaps before others. This flag provides
    *        the possibility to calculate the next swap information for privileged and non-privileged accounts
+   * @param oracleData Bytes to send to the oracle when executing a quote
    * @return swapInformation The information about the next swap
    */
   function getNextSwapInfo(
     address[] calldata tokens,
     PairIndexes[] calldata pairs,
-    bool calculatePrivilegedAvailability
+    bool calculatePrivilegedAvailability,
+    bytes calldata oracleData
   ) external view returns (SwapInfo memory swapInformation);
 
   /**
@@ -496,7 +500,8 @@ interface IDCAHubSwapHandler {
    * @param rewardRecipient The address to send the reward to
    * @param callbackHandler Address to call for callback (and send the borrowed tokens to)
    * @param borrow How much to borrow of each of the tokens in tokens. The amount must match the position of the token in the tokens array
-   * @param data Bytes to send to the caller during the callback
+   * @param callbackData Bytes to send to the caller during the callback
+   * @param oracleData Bytes to send to the oracle when executing a quote
    * @return Information about the executed swap
    */
   function swap(
@@ -505,7 +510,8 @@ interface IDCAHubSwapHandler {
     address rewardRecipient,
     address callbackHandler,
     uint256[] calldata borrow,
-    bytes calldata data
+    bytes calldata callbackData,
+    bytes calldata oracleData
   ) external returns (SwapInfo memory);
 }
 

--- a/contracts/interfaces/IDCAHub.sol
+++ b/contracts/interfaces/IDCAHub.sol
@@ -426,7 +426,9 @@ interface IDCAHubSwapHandler {
     address tokenA;
     // The address of the other token
     address tokenB;
+    // The total amount of token A swapped in this pair
     uint256 totalAmountToSwapTokenA;
+    // The total amount of token B swapped in this pair
     uint256 totalAmountToSwapTokenB;
     // How much is 1 unit of token A when converted to B
     uint256 ratioAToB;

--- a/contracts/mocks/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/mocks/DCAHub/DCAHubSwapHandler.sol
@@ -92,35 +92,51 @@ contract DCAHubSwapHandlerMock is DCAHubSwapHandler, DCAHubConfigHandlerMock {
   function getNextSwapInfo(
     address[] calldata _tokens,
     PairIndexes[] calldata _pairs,
-    bool _calculatePrivilegedAvailability
+    bool _calculatePrivilegedAvailability,
+    bytes calldata _oracleData
   ) public view override returns (SwapInfo memory) {
     if (_swapInformation.tokens.length > 0) {
       return _swapInformation;
     } else {
-      return super.getNextSwapInfo(_tokens, _pairs, _calculatePrivilegedAvailability);
+      return super.getNextSwapInfo(_tokens, _pairs, _calculatePrivilegedAvailability, _oracleData);
     }
   }
 
   function calculateRatio(
-    address _tokenA,
-    address _tokenB,
-    uint256 _magnitudeA,
-    uint256 _magnitudeB,
-    ITokenPriceOracle _oracle
-  ) external view returns (uint256, uint256) {
-    return _calculateRatio(_tokenA, _tokenB, _magnitudeA, _magnitudeB, _oracle);
+    PairInSwap memory _pairInSwap,
+    ITokenPriceOracle _oracle,
+    bytes calldata _oracleData
+  )
+    external
+    view
+    returns (
+      uint256,
+      uint256,
+      uint256,
+      uint256
+    )
+  {
+    return _calculateRatio(_pairInSwap, _oracle, _oracleData);
   }
 
   function _calculateRatio(
-    address _tokenA,
-    address _tokenB,
-    uint256 _magnitudeA,
-    uint256 _magnitudeB,
-    ITokenPriceOracle _oracle
-  ) internal view override returns (uint256 _ratioAToB, uint256 _ratioBToA) {
-    _ratioBToA = _ratios[_tokenB][_tokenA];
+    PairInSwap memory _pairInSwap,
+    ITokenPriceOracle _oracle,
+    bytes calldata _oracleData
+  )
+    internal
+    view
+    override
+    returns (
+      uint256 _ratioAToB,
+      uint256 _ratioBToA,
+      uint256 _magnitudeA,
+      uint256 _magnitudeB
+    )
+  {
+    _ratioBToA = _ratios[_pairInSwap.tokenB][_pairInSwap.tokenA];
     if (_ratioBToA == 0) {
-      return super._calculateRatio(_tokenA, _tokenB, _magnitudeA, _magnitudeB, _oracle);
+      return super._calculateRatio(_pairInSwap, _oracle, _oracleData);
     }
     _ratioAToB = (_magnitudeA * _magnitudeB) / _ratioBToA;
   }

--- a/contracts/mocks/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/mocks/DCAHub/DCAHubSwapHandler.sol
@@ -103,7 +103,8 @@ contract DCAHubSwapHandlerMock is DCAHubSwapHandler, DCAHubConfigHandlerMock {
   }
 
   function calculateRatio(
-    PairInSwap memory _pairInSwap,
+    address _tokenA,
+    address _tokenB,
     ITokenPriceOracle _oracle,
     bytes calldata _oracleData
   )
@@ -112,15 +113,15 @@ contract DCAHubSwapHandlerMock is DCAHubSwapHandler, DCAHubConfigHandlerMock {
     returns (
       uint256,
       uint256,
-      uint256,
-      uint256
+      PairMagnitudes memory
     )
   {
-    return _calculateRatio(_pairInSwap, _oracle, _oracleData);
+    return _calculateRatio(_tokenA, _tokenB, _oracle, _oracleData);
   }
 
   function _calculateRatio(
-    PairInSwap memory _pairInSwap,
+    address _tokenA,
+    address _tokenB,
     ITokenPriceOracle _oracle,
     bytes calldata _oracleData
   )
@@ -130,15 +131,16 @@ contract DCAHubSwapHandlerMock is DCAHubSwapHandler, DCAHubConfigHandlerMock {
     returns (
       uint256 _ratioAToB,
       uint256 _ratioBToA,
-      uint256 _magnitudeA,
-      uint256 _magnitudeB
+      PairMagnitudes memory _magnitudes
     )
   {
-    _ratioBToA = _ratios[_pairInSwap.tokenB][_pairInSwap.tokenA];
+    _ratioBToA = _ratios[_tokenB][_tokenA];
     if (_ratioBToA == 0) {
-      return super._calculateRatio(_pairInSwap, _oracle, _oracleData);
+      return super._calculateRatio(_tokenA, _tokenB, _oracle, _oracleData);
     }
-    _ratioAToB = (_magnitudeA * _magnitudeB) / _ratioBToA;
+    _magnitudes.magnitudeA = tokenMagnitude[_tokenA];
+    _magnitudes.magnitudeB = tokenMagnitude[_tokenB];
+    _ratioAToB = (_magnitudes.magnitudeA * _magnitudes.magnitudeB) / _ratioBToA;
   }
 
   // Used to register calls

--- a/test/e2e/DCAHub/active-intervals.spec.ts
+++ b/test/e2e/DCAHub/active-intervals.spec.ts
@@ -22,6 +22,7 @@ import { FakeContract, smock } from '@defi-wonderland/smock';
 import { snapshot } from '@test-utils/evm';
 
 contract('DCAHub', () => {
+  const BYTES = ethers.utils.hexlify(ethers.utils.randomBytes(5));
   let snapshotId: string;
   let governor: SignerWithAddress, john: SignerWithAddress;
   let tokenA: TokenContract, tokenB: TokenContract;
@@ -153,7 +154,7 @@ contract('DCAHub', () => {
 
   async function flashSwap({ callee }: { callee: HasAddress }) {
     const { tokens, pairIndexes, borrow } = buildSwapInput([{ tokenA: tokenA.address, tokenB: tokenB.address }], []);
-    await DCAHub.swap(tokens, pairIndexes, callee.address, callee.address, borrow, ethers.utils.randomBytes(5));
+    await DCAHub.swap(tokens, pairIndexes, callee.address, callee.address, borrow, BYTES, BYTES);
   }
 
   type HasAddress = {

--- a/test/e2e/DCAHub/allowed-tokens.spec.ts
+++ b/test/e2e/DCAHub/allowed-tokens.spec.ts
@@ -22,6 +22,7 @@ import { FakeContract, smock } from '@defi-wonderland/smock';
 import { snapshot } from '@test-utils/evm';
 
 contract('DCAHub', () => {
+  const BYTES = ethers.utils.hexlify(ethers.utils.randomBytes(5));
   let snapshotId: string;
   let governor: SignerWithAddress, john: SignerWithAddress;
   let tokenA: TokenContract, tokenB: TokenContract;
@@ -137,13 +138,13 @@ contract('DCAHub', () => {
     });
     const { tokens, pairIndexes, borrow } = buildSwapInput([{ tokenA: tokenA.address, tokenB: tokenB.address }], []);
     await DCAHub.setAllowedTokens([tokenA.address], [false]);
-    await expect(
-      DCAHub.swap(tokens, pairIndexes, DCAHubSwapCallee.address, DCAHubSwapCallee.address, borrow, ethers.utils.randomBytes(5))
-    ).to.be.revertedWith('UnallowedToken');
+    await expect(DCAHub.swap(tokens, pairIndexes, DCAHubSwapCallee.address, DCAHubSwapCallee.address, borrow, BYTES, BYTES)).to.be.revertedWith(
+      'UnallowedToken'
+    );
     await DCAHub.setAllowedTokens([tokenA.address, tokenB.address], [true, false]);
-    await expect(
-      DCAHub.swap(tokens, pairIndexes, DCAHubSwapCallee.address, DCAHubSwapCallee.address, borrow, ethers.utils.randomBytes(5))
-    ).to.be.revertedWith('UnallowedToken');
+    await expect(DCAHub.swap(tokens, pairIndexes, DCAHubSwapCallee.address, DCAHubSwapCallee.address, borrow, BYTES, BYTES)).to.be.revertedWith(
+      'UnallowedToken'
+    );
   });
 
   it('user flow works even allowing previously unallowed tokens', async () => {
@@ -162,9 +163,9 @@ contract('DCAHub', () => {
     expect(await tokenB.balanceOf(john.address)).to.be.gt(previousBalance);
     const { tokens, pairIndexes, borrow } = buildSwapInput([{ tokenA: tokenA.address, tokenB: tokenB.address }], []);
     await evm.advanceTimeAndBlock(SwapInterval.FIVE_MINUTES.seconds);
-    await expect(
-      DCAHub.swap(tokens, pairIndexes, DCAHubSwapCallee.address, DCAHubSwapCallee.address, borrow, ethers.utils.randomBytes(5))
-    ).to.be.revertedWith('UnallowedToken');
+    await expect(DCAHub.swap(tokens, pairIndexes, DCAHubSwapCallee.address, DCAHubSwapCallee.address, borrow, BYTES, BYTES)).to.be.revertedWith(
+      'UnallowedToken'
+    );
     await DCAHub.setAllowedTokens([tokenA.address, tokenB.address], [true, true]);
     await flashSwap({ callee: DCAHubSwapCallee });
     const previousBalanceA = await tokenA.balanceOf(john.address);
@@ -200,7 +201,7 @@ contract('DCAHub', () => {
 
   async function flashSwap({ callee }: { callee: HasAddress }) {
     const { tokens, pairIndexes, borrow } = buildSwapInput([{ tokenA: tokenA.address, tokenB: tokenB.address }], []);
-    await DCAHub.swap(tokens, pairIndexes, callee.address, callee.address, borrow, ethers.utils.randomBytes(5));
+    await DCAHub.swap(tokens, pairIndexes, callee.address, callee.address, borrow, ethers.utils.randomBytes(5), ethers.utils.randomBytes(5));
   }
 
   type HasAddress = {

--- a/test/e2e/DCAHub/happy-path.spec.ts
+++ b/test/e2e/DCAHub/happy-path.spec.ts
@@ -22,6 +22,7 @@ import { FakeContract, smock } from '@defi-wonderland/smock';
 import { Permission } from 'js-lib/types';
 
 contract('DCAHub', () => {
+  const BYTES = ethers.utils.hexlify(ethers.utils.randomBytes(5));
   describe('Full e2e test', () => {
     let governor: SignerWithAddress, john: SignerWithAddress;
     let lucy: SignerWithAddress, sarah: SignerWithAddress;
@@ -402,7 +403,7 @@ contract('DCAHub', () => {
         ],
         []
       );
-      await DCAHub.swap(tokens, pairIndexes, callee.address, callee.address, borrow, ethers.utils.randomBytes(5));
+      await DCAHub.swap(tokens, pairIndexes, callee.address, callee.address, borrow, BYTES, BYTES);
     }
 
     function getPosition(position: UserPositionDefinition): Promise<OngoingUserPosition> {
@@ -418,7 +419,7 @@ contract('DCAHub', () => {
         ],
         []
       );
-      return DCAHub.getNextSwapInfo(tokens, pairIndexes, true);
+      return DCAHub.getNextSwapInfo(tokens, pairIndexes, true, BYTES);
     }
 
     async function reducePosition(position: UserPositionDefinition, args: { newSwaps: number; amount: number }) {

--- a/test/e2e/DCAHub/max-rate.spec.ts
+++ b/test/e2e/DCAHub/max-rate.spec.ts
@@ -24,6 +24,7 @@ import { expect } from 'chai';
 contract('DCAHub', () => {
   // We are now making a test where a lot of positions use the max rate allowed
   describe('Max rate', () => {
+    const BYTES = ethers.utils.hexlify(ethers.utils.randomBytes(5));
     const MAX_UINT = BigNumber.from(2).pow(256).sub(1);
     const MAX_RATE = BigNumber.from(2).pow(120).sub(1); // max(uint120)
     const AMOUNT_OF_POSITIONS = 100;
@@ -99,7 +100,7 @@ contract('DCAHub', () => {
 
     async function assertThereIsNothingElseToSwap() {
       const { tokens, pairIndexes } = buildGetNextSwapInfoInput([{ tokenA: tokenA.address, tokenB: tokenB.address }], []);
-      const { pairs } = await DCAHub.getNextSwapInfo(tokens, pairIndexes, true);
+      const { pairs } = await DCAHub.getNextSwapInfo(tokens, pairIndexes, true, BYTES);
       expect(pairs[0].intervalsInSwap).to.equal('0x00');
     }
 
@@ -126,7 +127,7 @@ contract('DCAHub', () => {
     async function flashSwap({ times }: { times: number }) {
       const { tokens, pairIndexes, borrow } = buildSwapInput([{ tokenA: tokenA.address, tokenB: tokenB.address }], []);
       for (let i = 0; i < times; i++) {
-        await DCAHub.swap(tokens, pairIndexes, DCAHubSwapCallee.address, DCAHubSwapCallee.address, borrow, ethers.utils.randomBytes(5));
+        await DCAHub.swap(tokens, pairIndexes, DCAHubSwapCallee.address, DCAHubSwapCallee.address, borrow, BYTES, BYTES);
         await evm.advanceTimeAndBlock(SwapInterval.ONE_DAY.seconds * 2);
       }
     }

--- a/test/e2e/DCAHub/position-interaction.spec.ts
+++ b/test/e2e/DCAHub/position-interaction.spec.ts
@@ -23,6 +23,7 @@ import { snapshot } from '@test-utils/evm';
 contract('DCAHub', () => {
   // We are now making sure that positions can still be interacted with (without reverts) in certain contexts
   describe('Position Interaction', () => {
+    const BYTES = ethers.utils.hexlify(ethers.utils.randomBytes(5));
     const MAX_UINT_120 = BigNumber.from(2).pow(120).sub(1); // max(uint120)
     const TOTAL_AMOUNT_OF_SWAPS = 2;
 
@@ -211,7 +212,7 @@ contract('DCAHub', () => {
           [tokenA.address, tokenB.address],
           [await tokenA.balanceOf(DCAHubSwapCallee.address), await tokenB.balanceOf(DCAHubSwapCallee.address)]
         );
-        await DCAHub.swap(tokens, pairIndexes, DCAHubSwapCallee.address, DCAHubSwapCallee.address, borrow, ethers.utils.randomBytes(5));
+        await DCAHub.swap(tokens, pairIndexes, DCAHubSwapCallee.address, DCAHubSwapCallee.address, borrow, BYTES, BYTES);
         await evm.advanceTimeAndBlock(SwapInterval.ONE_DAY.seconds * 2);
       }
     }

--- a/test/e2e/DCAHub/precision-breaker.spec.ts
+++ b/test/e2e/DCAHub/precision-breaker.spec.ts
@@ -20,6 +20,7 @@ import { SwapInterval } from 'js-lib/interval-utils';
 
 contract('DCAHub', () => {
   describe('Precision breaker', () => {
+    const BYTES = ethers.utils.hexlify(ethers.utils.randomBytes(5));
     const PLATFORM_WITHDRAW_ROLE: string = new Web3().utils.soliditySha3('PLATFORM_WITHDRAW_ROLE') as string;
 
     let governor: SignerWithAddress;
@@ -130,7 +131,7 @@ contract('DCAHub', () => {
 
     async function flashSwap({ callee }: { callee: HasAddress }) {
       const { tokens, pairIndexes, borrow } = buildSwapInput([{ tokenA: tokenA.address, tokenB: tokenB.address }], []);
-      await DCAHub.swap(tokens, pairIndexes, callee.address, callee.address, borrow, ethers.utils.randomBytes(5));
+      await DCAHub.swap(tokens, pairIndexes, callee.address, callee.address, borrow, BYTES, BYTES);
     }
 
     async function setInitialBalance(

--- a/test/e2e/DCAHub/precision-low-decimal-tokens.spec.ts
+++ b/test/e2e/DCAHub/precision-low-decimal-tokens.spec.ts
@@ -21,6 +21,7 @@ import { snapshot } from '@test-utils/evm';
 
 contract('DCAHub', () => {
   describe('Precision with low decimal tokens', () => {
+    const BYTES = ethers.utils.hexlify(ethers.utils.randomBytes(5));
     const PRICE_IN_USDC = 100;
 
     let governor: SignerWithAddress;
@@ -104,7 +105,7 @@ contract('DCAHub', () => {
 
     async function swap({ callee }: { callee: HasAddress }) {
       const { tokens, pairIndexes, borrow } = buildSwapInput([{ tokenA: USDC.address, tokenB: myToken.address }], []);
-      await DCAHub.swap(tokens, pairIndexes, callee.address, callee.address, borrow, ethers.utils.randomBytes(5));
+      await DCAHub.swap(tokens, pairIndexes, callee.address, callee.address, borrow, BYTES, BYTES);
     }
 
     async function setInitialBalance(

--- a/test/e2e/DCAHub/reentrancy-guard.spec.ts
+++ b/test/e2e/DCAHub/reentrancy-guard.spec.ts
@@ -22,6 +22,7 @@ import { FakeContract, smock } from '@defi-wonderland/smock';
 
 contract('DCAHub', () => {
   describe('Reentrancy Guard', () => {
+    const BYTES = ethers.utils.hexlify(ethers.utils.randomBytes(5));
     let governor: SignerWithAddress;
     let dude: SignerWithAddress;
     let tokenA: TokenContract, tokenB: TokenContract;
@@ -193,7 +194,7 @@ contract('DCAHub', () => {
         args,
         attackerContract,
         attack: async () => {
-          const result = await DCAHub.populateTransaction.swap([], [], constants.NOT_ZERO_ADDRESS, constants.NOT_ZERO_ADDRESS, [], '0x');
+          const result = await DCAHub.populateTransaction.swap([], [], constants.NOT_ZERO_ADDRESS, constants.NOT_ZERO_ADDRESS, [], BYTES, BYTES);
           return result.data!;
         },
       });

--- a/test/e2e/DCAHub/reentrancy-guard.spec.ts
+++ b/test/e2e/DCAHub/reentrancy-guard.spec.ts
@@ -74,13 +74,14 @@ contract('DCAHub', () => {
       });
 
       testReentrantForFunction({
-        funcAndSignature: 'swap(address[],(uint8,uint8)[],address,address,uint256[],bytes)',
+        funcAndSignature: 'swap',
         args: () => [
           [tokenA.address, tokenB.address],
           [{ indexTokenA: 0, indexTokenB: 1 }],
           reentrantDCAHubSwapCallee.address,
           reentrantDCAHubSwapCallee.address,
           [0, 0],
+          utils.formatBytes32String(''),
           utils.formatBytes32String(''),
         ],
         attackerContract: () => reentrantDCAHubSwapCallee,

--- a/test/integration/DCAHubPositionDescriptor/dca-hub-position-descriptor.spec.ts
+++ b/test/integration/DCAHubPositionDescriptor/dca-hub-position-descriptor.spec.ts
@@ -127,7 +127,7 @@ describe('DCAHubPositionDescriptor', () => {
 
   async function swap() {
     const { tokens, pairIndexes, borrow } = buildSwapInput([{ tokenA: WETH.address, tokenB: USDC.address }], []);
-    await DCAHub.swap(tokens, pairIndexes, DCAHubSwapCallee.address, DCAHubSwapCallee.address, borrow, []);
+    await DCAHub.swap(tokens, pairIndexes, DCAHubSwapCallee.address, DCAHubSwapCallee.address, borrow, [], []);
     await evm.advanceTimeAndBlock(SWAP_INTERVAL);
   }
 


### PR DESCRIPTION
@0xged mentioned that since our new oracles can take some bytes as part of the quote, we could send those bytes as part of the swap

This PR adds support for this