### PR TITLE
refactor: remove structs from interfaces

### DIFF
--- a/contracts/DCAHub/DCAHubPositionHandler.sol
+++ b/contracts/DCAHub/DCAHubPositionHandler.sol
@@ -271,19 +271,19 @@ abstract contract DCAHubPositionHandler is ReentrancyGuard, DCAHubConfigHandler,
   ) internal {
     if (_from < _to) {
       if (_add) {
-        _swapData[_from][_to][_swapIntervalMask].nextAmountToSwapAToB += _rate;
-        _swapAmountDelta[_from][_to][_swapIntervalMask][_finalSwap + 1].swapDeltaAToB += _rate;
+        swapData[_from][_to][_swapIntervalMask].nextAmountToSwapAToB += _rate;
+        swapAmountDelta[_from][_to][_swapIntervalMask][_finalSwap + 1].swapDeltaAToB += _rate;
       } else {
-        _swapData[_from][_to][_swapIntervalMask].nextAmountToSwapAToB -= _rate;
-        _swapAmountDelta[_from][_to][_swapIntervalMask][_finalSwap + 1].swapDeltaAToB -= _rate;
+        swapData[_from][_to][_swapIntervalMask].nextAmountToSwapAToB -= _rate;
+        swapAmountDelta[_from][_to][_swapIntervalMask][_finalSwap + 1].swapDeltaAToB -= _rate;
       }
     } else {
       if (_add) {
-        _swapData[_to][_from][_swapIntervalMask].nextAmountToSwapBToA += _rate;
-        _swapAmountDelta[_to][_from][_swapIntervalMask][_finalSwap + 1].swapDeltaBToA += _rate;
+        swapData[_to][_from][_swapIntervalMask].nextAmountToSwapBToA += _rate;
+        swapAmountDelta[_to][_from][_swapIntervalMask][_finalSwap + 1].swapDeltaBToA += _rate;
       } else {
-        _swapData[_to][_from][_swapIntervalMask].nextAmountToSwapBToA -= _rate;
-        _swapAmountDelta[_to][_from][_swapIntervalMask][_finalSwap + 1].swapDeltaBToA -= _rate;
+        swapData[_to][_from][_swapIntervalMask].nextAmountToSwapBToA -= _rate;
+        swapAmountDelta[_to][_from][_swapIntervalMask][_finalSwap + 1].swapDeltaBToA -= _rate;
       }
     }
   }
@@ -321,12 +321,12 @@ abstract contract DCAHubPositionHandler is ReentrancyGuard, DCAHubConfigHandler,
 
     uint256 _positionsAccumRatio;
     if (_userPosition.from < _userPosition.to) {
-      mapping(uint32 => AccumRatio) storage _accumRatioRef = _accumRatio[_userPosition.from][_userPosition.to][_userPosition.swapIntervalMask];
+      mapping(uint32 => AccumRatio) storage _accumRatioRef = accumRatio[_userPosition.from][_userPosition.to][_userPosition.swapIntervalMask];
       _positionsAccumRatio =
         _accumRatioRef[_newestSwapToConsider].accumRatioAToB -
         _accumRatioRef[_userPosition.swapWhereLastUpdated].accumRatioAToB;
     } else {
-      mapping(uint32 => AccumRatio) storage _accumRatioRef = _accumRatio[_userPosition.to][_userPosition.from][_userPosition.swapIntervalMask];
+      mapping(uint32 => AccumRatio) storage _accumRatioRef = accumRatio[_userPosition.to][_userPosition.from][_userPosition.swapIntervalMask];
       _positionsAccumRatio =
         _accumRatioRef[_newestSwapToConsider].accumRatioBToA -
         _accumRatioRef[_userPosition.swapWhereLastUpdated].accumRatioBToA;
@@ -360,7 +360,7 @@ abstract contract DCAHubPositionHandler is ReentrancyGuard, DCAHubConfigHandler,
     bytes1 _swapIntervalMask
   ) internal view returns (uint32) {
     (address _tokenA, address _tokenB) = TokenSorting.sortTokens(_from, _to);
-    return _swapData[_tokenA][_tokenB][_swapIntervalMask].performedSwaps;
+    return swapData[_tokenA][_tokenB][_swapIntervalMask].performedSwaps;
   }
 
   function _buildPosition(

--- a/contracts/DCAHub/DCAHubSwapHandler.sol
+++ b/contracts/DCAHub/DCAHubSwapHandler.sol
@@ -25,10 +25,10 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
     uint256 _ratioBToA,
     uint32 _timestamp
   ) internal virtual {
-    SwapData memory _swapDataMem = _swapData[_tokenA][_tokenB][_swapIntervalMask];
+    SwapData memory _swapDataMem = swapData[_tokenA][_tokenB][_swapIntervalMask];
     if (_swapDataMem.nextAmountToSwapAToB > 0 || _swapDataMem.nextAmountToSwapBToA > 0) {
-      mapping(uint32 => AccumRatio) storage _accumRatioRef = _accumRatio[_tokenA][_tokenB][_swapIntervalMask];
-      mapping(uint32 => SwapDelta) storage _swapAmountDeltaRef = _swapAmountDelta[_tokenA][_tokenB][_swapIntervalMask];
+      mapping(uint32 => AccumRatio) storage _accumRatioRef = accumRatio[_tokenA][_tokenB][_swapIntervalMask];
+      mapping(uint32 => SwapDelta) storage _swapAmountDeltaRef = swapAmountDelta[_tokenA][_tokenB][_swapIntervalMask];
       AccumRatio memory _accumRatioMem = _accumRatioRef[_swapDataMem.performedSwaps];
       _accumRatioRef[_swapDataMem.performedSwaps + 1] = AccumRatio({
         accumRatioAToB: _accumRatioMem.accumRatioAToB + _ratioAToB,
@@ -37,7 +37,7 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
       SwapDelta memory _swapDeltaMem = _swapAmountDeltaRef[_swapDataMem.performedSwaps + 2];
       uint224 _nextAmountToSwapAToB = _swapDataMem.nextAmountToSwapAToB - _swapDeltaMem.swapDeltaAToB;
       uint224 _nextAmountToSwapBToA = _swapDataMem.nextAmountToSwapBToA - _swapDeltaMem.swapDeltaBToA;
-      _swapData[_tokenA][_tokenB][_swapIntervalMask] = SwapData({
+      swapData[_tokenA][_tokenB][_swapIntervalMask] = SwapData({
         performedSwaps: _swapDataMem.performedSwaps + 1,
         lastSwappedAt: _timestamp,
         nextAmountToSwapAToB: _nextAmountToSwapAToB,
@@ -87,7 +87,7 @@ abstract contract DCAHubSwapHandler is ReentrancyGuard, DCAHubConfigHandler, IDC
     bytes1 _mask = 0x01;
     while (_activeIntervals >= _mask && _mask > 0) {
       if (_activeIntervals & _mask != 0) {
-        SwapData memory _swapDataMem = _swapData[_tokenA][_tokenB][_mask];
+        SwapData memory _swapDataMem = swapData[_tokenA][_tokenB][_mask];
         uint32 _swapInterval = Intervals.maskToInterval(_mask);
         uint32 _nextSwapAvailableAt = ((_swapDataMem.lastSwappedAt / _swapInterval) + 1) * _swapInterval;
         if (!_calculatePrivilegedAvailability) {

--- a/contracts/interfaces/IDCAHub.sol
+++ b/contracts/interfaces/IDCAHub.sol
@@ -10,79 +10,64 @@ import './IDCAPermissionManager.sol';
  * @notice These methods allow users to read the hubs's current values
  */
 interface IDCAHubParameters {
-  /// @notice Swap information about a specific pair
-  struct SwapData {
-    // How many swaps have been executed
-    uint32 performedSwaps;
-    // How much of token A will be swapped on the next swap
-    uint224 nextAmountToSwapAToB;
-    // Timestamp of the last swap
-    uint32 lastSwappedAt;
-    // How much of token B will be swapped on the next swap
-    uint224 nextAmountToSwapBToA;
-  }
-
-  /// @notice The difference of tokens to swap between a swap, and the previous one
-  struct SwapDelta {
-    // How much less of token A will the following swap require
-    uint128 swapDeltaAToB;
-    // How much less of token B will the following swap require
-    uint128 swapDeltaBToA;
-  }
-
-  /// @notice The sum of the ratios the oracle reported in all executed swaps
-  struct AccumRatio {
-    // The sum of all ratios from A to B
-    uint256 accumRatioAToB;
-    // The sum of all ratios from B to A
-    uint256 accumRatioBToA;
-  }
-
   /**
    * @notice Returns how much will the amount to swap differ from the previous swap. f.e. if the returned value is -100, then the amount to swap will be 100 less than the swap just before it
-   * @dev tokenA and tokenB may be passed in either tokenA/tokenB or tokenB/tokenA order
+   * @dev `tokenA` must be smaller than `tokenB` (tokenA < tokenB)
    * @param tokenA One of the pair's token
    * @param tokenB The other of the pair's token
    * @param swapIntervalMask The byte representation of the swap interval to check
    * @param swapNumber The swap number to check
-   * @return How much will the amount to swap differ, when compared to the swap just before this one
+   * @return swapDeltaAToB How much less of token A will the following swap require
+   * @return swapDeltaBToA How much less of token B will the following swap require
    */
   function swapAmountDelta(
     address tokenA,
     address tokenB,
     bytes1 swapIntervalMask,
     uint32 swapNumber
-  ) external view returns (SwapDelta memory);
+  ) external view returns (uint128 swapDeltaAToB, uint128 swapDeltaBToA);
 
   /**
    * @notice Returns the sum of the ratios reported in all swaps executed until the given swap number
-   * @dev tokenA and tokenB may be passed in either tokenA/tokenB or tokenB/tokenA order
+   * @dev `tokenA` must be smaller than `tokenB` (tokenA < tokenB)
    * @param tokenA One of the pair's token
    * @param tokenB The other of the pair's token
    * @param swapIntervalMask The byte representation of the swap interval to check
    * @param swapNumber The swap number to check
-   * @return The sum of the ratios
+   * @return accumRatioAToB The sum of all ratios from A to B
+   * @return accumRatioBToA The sum of all ratios from B to A
    */
   function accumRatio(
     address tokenA,
     address tokenB,
     bytes1 swapIntervalMask,
     uint32 swapNumber
-  ) external view returns (AccumRatio memory);
+  ) external view returns (uint256 accumRatioAToB, uint256 accumRatioBToA);
 
   /**
    * @notice Returns swapping information about a specific pair
-   * @dev tokenA and tokenB may be passed in either tokenA/tokenB or tokenB/tokenA order
+   * @dev `tokenA` must be smaller than `tokenB` (tokenA < tokenB)
    * @param tokenA One of the pair's token
    * @param tokenB The other of the pair's token
    * @param swapIntervalMask The byte representation of the swap interval to check
-   * @return The swapping information
+   * @return performedSwaps How many swaps have been executed
+   * @return nextAmountToSwapAToB How much of token A will be swapped on the next swap
+   * @return lastSwappedAt Timestamp of the last swap
+   * @return nextAmountToSwapBToA How much of token B will be swapped on the next swap
    */
   function swapData(
     address tokenA,
     address tokenB,
     bytes1 swapIntervalMask
-  ) external view returns (SwapData memory);
+  )
+    external
+    view
+    returns (
+      uint32 performedSwaps,
+      uint224 nextAmountToSwapAToB,
+      uint32 lastSwappedAt,
+      uint224 nextAmountToSwapBToA
+    );
 
   /**
    * @notice Returns the byte representation of the set of actice swap intervals for the given pair

--- a/contracts/mocks/DCAHub/DCAHubParameters.sol
+++ b/contracts/mocks/DCAHub/DCAHubParameters.sol
@@ -25,7 +25,7 @@ contract DCAHubParametersMock is DCAHubParameters {
     uint128 _deltaAToB,
     uint128 _deltaBToA
   ) external {
-    _swapAmountDelta[_tokenA][_tokenB][_swapIntervalMask][_swap] = SwapDelta(_deltaAToB, _deltaBToA);
+    swapAmountDelta[_tokenA][_tokenB][_swapIntervalMask][_swap] = SwapDelta(_deltaAToB, _deltaBToA);
   }
 
   function setAcummRatio(
@@ -36,7 +36,7 @@ contract DCAHubParametersMock is DCAHubParameters {
     uint256 _accumRatioAToB,
     uint256 _accumRatioBToA
   ) external {
-    _accumRatio[_tokenA][_tokenB][_swapIntervalMask][_swap] = AccumRatio(_accumRatioAToB, _accumRatioBToA);
+    accumRatio[_tokenA][_tokenB][_swapIntervalMask][_swap] = AccumRatio(_accumRatioAToB, _accumRatioBToA);
   }
 
   function setNextAmountsToSwap(
@@ -46,8 +46,8 @@ contract DCAHubParametersMock is DCAHubParameters {
     uint224 _amountToSwapAToB,
     uint224 _amountToSwapBToA
   ) external {
-    _swapData[_tokenA][_tokenB][_swapIntervalMask].nextAmountToSwapAToB = _amountToSwapAToB;
-    _swapData[_tokenA][_tokenB][_swapIntervalMask].nextAmountToSwapBToA = _amountToSwapBToA;
+    swapData[_tokenA][_tokenB][_swapIntervalMask].nextAmountToSwapAToB = _amountToSwapAToB;
+    swapData[_tokenA][_tokenB][_swapIntervalMask].nextAmountToSwapBToA = _amountToSwapBToA;
   }
 
   function setPerformedSwaps(
@@ -56,7 +56,7 @@ contract DCAHubParametersMock is DCAHubParameters {
     bytes1 _swapIntervalMask,
     uint32 _performedSwaps
   ) external {
-    _swapData[_tokenA][_tokenB][_swapIntervalMask].performedSwaps = _performedSwaps;
+    swapData[_tokenA][_tokenB][_swapIntervalMask].performedSwaps = _performedSwaps;
   }
 
   function setLastSwappedAt(
@@ -65,6 +65,6 @@ contract DCAHubParametersMock is DCAHubParameters {
     bytes1 _swapIntervalMask,
     uint32 _lastSwappedAt
   ) external {
-    _swapData[_tokenA][_tokenB][_swapIntervalMask].lastSwappedAt = _lastSwappedAt;
+    swapData[_tokenA][_tokenB][_swapIntervalMask].lastSwappedAt = _lastSwappedAt;
   }
 }


### PR DESCRIPTION
Based on the last few changes, we need to reduce the contract size. But the thing is that Solidity sucks, a lot. If we make our mappings public, then the interface type differs. Instead of having a struct, they need to be a list of separate types